### PR TITLE
feat(dependencies): Add unitxt as an explicit dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "dill==0.3.8",
     "word2number==1.1",
     "more_itertools==10.5.0",
+    "unitxt==1.15.7",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Using pinned version 1.15.7

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Adding `unitxt` as an explicit, pinned version of lm-evaluation-harness.
This prevents dynamic runtime installation of  `unitxt` when a unitxt tasks determines this package to be missing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
