### PR TITLE
fix: Wrong metrics path prefix for offline LMEval

### DIFF
--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -19,7 +19,7 @@ if os.environ.get("HF_EVALUATE_OFFLINE") == "1":
     evaluate_load = evaluate.load
 
     # Use the specified metrics prefix. If not set use the default.
-    LMEVAL_METRICS_PREFIX = os.getenv("LMEVAL_METRICS_PREFIX", "lm-evaluation-harness/metrics")
+    LMEVAL_METRICS_PREFIX = os.getenv("LMEVAL_METRICS_PREFIX", "/opt/app-root/src/metrics")
 
     # Load the metrics from the centralised folder
     def load_from_path(path, *args, **kwargs):

--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -19,7 +19,7 @@ if os.environ.get("HF_EVALUATE_OFFLINE") == "1":
     evaluate_load = evaluate.load
 
     # Use the specified metrics prefix. If not set use the default.
-    LMEVAL_METRICS_PREFIX = os.getenv("LMEVAL_METRICS_PREFIX", "metrics")
+    LMEVAL_METRICS_PREFIX = os.getenv("LMEVAL_METRICS_PREFIX", "lm-evaluation-harness/metrics")
 
     # Load the metrics from the centralised folder
     def load_from_path(path, *args, **kwargs):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When in offline mode, metrics were being loaded from `metrics` by default.
Taking into account the work directory of LMEval, this should be the absolute path `/opt/app-root/src/metrics`.
Refer to [RHOAIENG-18241](https://issues.redhat.com/browse/RHOAIENG-18241).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
