### PR TITLE
fix: Replace UNITXT_ARTIFACTORIES with UNITXT_CATALOGS

### DIFF
--- a/Dockerfile.lmes-job
+++ b/Dockerfile.lmes-job
@@ -22,7 +22,6 @@ RUN python -c 'from lm_eval.tasks.unitxt import task; import os.path; print("cla
 
 ENV PYTHONPATH=/opt/app-root/src/.local/lib/python3.11/site-packages:/opt/app-root/src/lm-evaluation-harness:/opt/app-root/src:/opt/app-root/src/server
 ENV HF_HOME=/opt/app-root/src/hf_home
-ENV UNITXT_ARTIFACTORIES=/opt/app-root/src/my_catalogs
+ENV UNITXT_CATALOGS=/opt/app-root/src/my_catalogs
 
 CMD ["/opt/app-root/bin/python"]
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`UNITXT_ARTIFACTORIES` env var is deprecated. This PR replaces it with `UNITXT_CATALOGS`.
Refer to [RHOAIENG-18617](https://issues.redhat.com/browse/RHOAIENG-18617) and https://github.com/trustyai-explainability/trustyai-service-operator/issues/392

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
