### PR TITLE
Changing base image to python-311:latest

### DIFF
--- a/Dockerfile.lmes-job
+++ b/Dockerfile.lmes-job
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/python-311@sha256:fccda5088dd13d2a3f2659e4c904beb42fc164a0c909e765f01af31c58affae3
+FROM registry.access.redhat.com/ubi9/python-311:latest
 
 USER root
 RUN sed -i.bak 's/include-system-site-packages = false/include-system-site-packages = true/' /opt/app-root/pyvenv.cfg


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This fixes issue https://github.com/opendatahub-io/lm-evaluation-harness/issues/21

## Description
With RHOAI on Open Shift 4.17.9 running LM-Eval, I've noticed that there are 77 vulnerabilities in the base python311 image.  By updating it to use the latest python311 image, this fixes all but 6 vulnerabilities.  Details of the vulnerabilities and their CVE, severity are in the issue.

The change suggested is to switch from:
```
registry.access.redhat.com/ubi9/python-311@sha256:fccda5088dd13d2a3f2659e4c904beb42fc164a0c909e765f01af31c58affae3](http://registry.access.redhat.com/ubi9/python-311@sha256:fccda5088dd13d2a3f2659e4c904beb42fc164a0c909e765f01af31c58affae3)
```
to
```
registry.access.redhat.com/ubi9/python-311:latest
```

## How Has This Been Tested?

I made the change in my branch and built it with:
`docker build -f Dockerfile.lmes-job -t jbusche-lmes-pod-img:latest2 .`
I then pushed this to quay:
```
podman tag localhost/jbusche-lmes-pod-img:latest2 quay.io/jbusche/lmes-pod-img:latest2
podman push quay.io/jbusche/lmes-pod-img:latest2
```
And then ran the twistlock (security scan) against this image and see that it's fixed over 90% of the vulnerabilities.

I then edited my configmap:
```
oc edit cm trustyai-service-operator-config -n redhat-ods-applications
```
and changed the lmes-pod-image to my newly built image:
```
lmes-pod-image: quay.io/jbusche/lmes-pod-img:latest2
```

I then restarted the trustyai pod:
```
oc scale deploy trustyai-service-operator-controller-manager -n redhat-ods-applications --replicas=0
oc scale deploy trustyai-service-operator-controller-manager -n redhat-ods-applications --replicas=1
```
And then deployed both some online LM-Eval jobs and offline jobs:

Online:
```
cat <<EOF | kubectl apply -f -
apiVersion: trustyai.opendatahub.io/v1alpha1
kind: LMEvalJob
metadata:
  name: "lmeval-glue"
  namespace: test
spec:
  allowOnline: true
  allowCodeExecution: true
  model: hf
  modelArgs:
  - name: pretrained
    value: google/flan-t5-base
  taskList:
    taskRecipes:
    - card:
        name: "cards.wnli"
      template: "templates.classification.multi_class.relation.default"
  logSamples: true
EOF
```
And:
```
cat <<EOF | kubectl apply -f -
apiVersion: trustyai.opendatahub.io/v1alpha1
kind: LMEvalJob
metadata:
  name: "online-unitxt"
  namespace: test
spec:
  allowOnline: true
  model: hf
  modelArgs:
    - name: pretrained
      value: "google/flan-t5-base"
  taskList:
    taskRecipes:
      - card:
          name: "cards.20_newsgroups_short"
        template: "templates.classification.multi_class.title"
  logSamples: true
EOF
```
These are succeeding on both my OC 4.17.9 FIPS and non-FIPS clusters:
```
oc get pods
NAME                  READY   STATUS      RESTARTS   AGE
lmeval-glue           0/1     Completed   0          56m
online-unitxt         1/1     Running     0          56m
```

I also tried an offline arceasy job:
```
cat << EOF | oc apply -f -
apiVersion: trustyai.opendatahub.io/v1alpha1
kind: LMEvalJob
metadata:
  name: "lmeval-arceasy-test"
  labels:
    opendatahub.io/dashboard: "true"
    lmevaltests: "vllm"
spec:
  model: hf
  modelArgs:
    - name: pretrained
      value: "/opt/app-root/src/hf_home/flan"
  taskList:
    taskNames:
      - "arc_easy"
  logSamples: true
  offline:
    storage:
      pvcName: "lmeval-data"
  pod:
    container:
      env:
        - name: HF_HUB_VERBOSITY
          value: "debug"
        - name: UNITXT_DEFAULT_VERBOSITY
          value: "debug"
EOF
```
and that looks good:
```
oc get pods
NAME                  READY   STATUS      RESTARTS   AGE
lmeval-arceasy-test   0/1     Completed   0          55m
```

Lastly, I'm trying the unitxt offline job:
```
cat << EOF | oc apply -f -
apiVersion: trustyai.opendatahub.io/v1alpha1
kind: LMEvalJob
metadata:
  name: "lmeval-unitxt-test"
spec:
  model: hf
  modelArgs:
    - name: pretrained
      value: "/opt/app-root/src/hf_home/flan"
  taskList:
    taskRecipes:
      - card:
          name: "cards.20_newsgroups_short"
        template: "templates.classification.multi_class.title"
  logSamples: true
  offline:
    storage:
      pvcName: "lmeval-data"
  pod:
    container:
      env:
        - name: HF_HUB_VERBOSITY
          value: "debug"
        - name: UNITXT_DEFAULT_VERBOSITY
          value: "debug"
EOF
```
And it looks like it's running OK so far:
```
oc get pods
NAME                 READY   STATUS    RESTARTS   AGE
lmeval-unitxt-test   1/1     Running   0          8m11s
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
