### PR TITLE
chore: Cherry-pick unitxt configuration update

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3851,14 +3851,14 @@ files = [
 
 [[package]]
 name = "unitxt"
-version = "1.15.7"
+version = "1.17.2"
 description = "Load any mixture of text to text data in one line of code"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "unitxt-1.15.7-py3-none-any.whl", hash = "sha256:17084d4f54a75552d84337289414f40f68da9bb814949c046c0192e7590de8f0"},
-    {file = "unitxt-1.15.7.tar.gz", hash = "sha256:66989c826b1365fca99ca196a923e8445cf86044a5adcc43c9ccf6264e0cfada"},
+    {file = "unitxt-1.17.2-py3-none-any.whl", hash = "sha256:0876ac3bae14daa215f50f4afc4f3dfc3b47e3792b504f0f3d161a1eab608410"},
+    {file = "unitxt-1.17.2.tar.gz", hash = "sha256:6af8abc8c6198d82a49b1628f3ba4fd50029115c031c70f39aca3196df718b7a"},
 ]
 
 [package.dependencies]
@@ -3869,13 +3869,14 @@ ipadic = "*"
 scipy = "*"
 
 [package.extras]
-all = ["unitxt[base]", "unitxt[dev]", "unitxt[docs]", "unitxt[helm]", "unitxt[service]", "unitxt[tests]", "unitxt[ui]", "unitxt[watsonx]"]
+all = ["unitxt[assistant]", "unitxt[base]", "unitxt[dev]", "unitxt[docs]", "unitxt[helm]", "unitxt[service]", "unitxt[tests]", "unitxt[ui]", "unitxt[watsonx]"]
+assistant = ["litellm", "streamlit", "watchdog"]
 dev = ["codespell", "detect-secrets", "fuzzywuzzy", "httpretty", "pre-commit", "ruff", "tomli"]
 docs = ["absl-py", "datasets", "editdistance", "evaluate", "fuzzywuzzy", "jiwer", "nltk", "piccolo_theme", "rouge_score", "sacrebleu", "scikit-learn", "sphinx_rtd_theme", "sphinxext-opengraph"]
 helm = ["crfm-helm[unitxt] (>=0.5.3)"]
 inference-tests = ["diskcache", "litellm (==v1.52.9)", "numpy (==1.26.4)", "tenacity"]
 service = ["fastapi (==0.109.0)", "python-jose[cryptography] (==3.3.0)", "torch (==1.12.1)", "transformers", "uvicorn[standard] (==0.27.0.post1)"]
-tests = ["SentencePiece", "accelerate", "bert_score", "bs4", "conllu", "editdistance", "fuzzywuzzy", "httpretty (>=1.1.4,<1.2.0)", "ibm-cos-sdk", "ibm-generative-ai", "jiwer", "kaggle (==1.6.14)", "llama-index-core", "llama-index-llms-openai", "mecab-python3", "nltk", "openai", "opendatasets", "pytrec-eval", "rouge-score", "sacrebleu[ko]", "scikit-learn", "sentence_transformers", "spacy", "tenacity (==8.3.0)", "transformers"]
+tests = ["SentencePiece", "Wikipedia-API", "accelerate", "bert_score", "bs4", "conllu", "editdistance", "func_timeout (==4.3.5)", "fuzzywuzzy", "httpretty (>=1.1.4,<1.2.0)", "ibm-cos-sdk", "ibm-generative-ai", "jiwer", "kaggle (==1.6.14)", "llama-index-core", "llama-index-llms-openai", "mecab-python3", "nltk", "openai", "opendatasets", "pytrec-eval", "rouge-score", "sacrebleu[ko]", "scikit-learn (<=1.5.2)", "sentence_transformers", "spacy", "sqlglot", "tenacity (==8.3.0)", "transformers"]
 ui = ["gradio", "transformers"]
 watsonx = ["ibm-watsonx-ai (==1.1.14)"]
 
@@ -4325,4 +4326,4 @@ testing = ["pytest", "pytest-cov", "pytest-xdist"]
 [metadata]
 lock-version = "2.1"
 python-versions = "<3.13,>=3.10"
-content-hash = "6a87eb533b7935df7c5b186a0f02204bfedb177fcc0e58fb33080b840b40dd08"
+content-hash = "a081df161d43901cd18f0398b0da0ed7e726dc8f06ad4ec6db3772966f1e8747"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "dill==0.3.8",
     "word2number==1.1",
     "more_itertools==10.5.0",
-    "unitxt==1.15.7",
+    "unitxt==1.17.2",
     "jiwer==3.0.5",
     "boto3==1.36.11",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -107,7 +107,7 @@ triton==3.2.0 ; python_version >= "3.10" and python_version < "3.13" and platfor
 typepy==1.3.4 ; python_version >= "3.10" and python_version < "3.13"
 typing-extensions==4.13.2 ; python_version >= "3.10" and python_version < "3.13"
 tzdata==2025.2 ; python_version >= "3.10" and python_version < "3.13"
-unitxt==1.15.7 ; python_version >= "3.10" and python_version < "3.13"
+unitxt==1.17.2 ; python_version >= "3.10" and python_version < "3.13"
 urllib3==2.1.0 ; python_version >= "3.10" and python_version < "3.13"
 word2number==1.1 ; python_version >= "3.10" and python_version < "3.13"
 xxhash==3.5.0 ; python_version >= "3.10" and python_version < "3.13"

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -13,18 +13,29 @@ from .utils import new_tasks
 
 datasets.config.HF_DATASETS_TRUST_REMOTE_CODE = True
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
-task_manager = tasks.TaskManager()
 # Default Task
 TASKS = ["arc_easy"]
 
 
-def task_class():
+def get_new_tasks_else_default():
+    """
+    Check if any modifications have been made to built-in tasks and return
+    the list, otherwise return the default task list
+    """
     global TASKS
     # CI: new_tasks checks if any modifications have been made
     task_classes = new_tasks()
     # Check if task_classes is empty
-    task_classes = task_classes if task_classes else TASKS
-    res = tasks.get_task_dict(task_classes, task_manager)
+    return task_classes if task_classes else TASKS
+
+
+def task_class(task_names=None, task_manager=None) -> ConfigurableTask:
+    """
+    Convert a list of task names to a list of ConfigurableTask instances
+    """
+    if task_manager is None:
+        task_manager = tasks.TaskManager()
+    res = tasks.get_task_dict(task_names, task_manager)
     res = [x.task for x in get_task_list(res)]
 
     return res
@@ -36,8 +47,11 @@ def limit() -> int:
 
 
 # Tests
-@pytest.mark.parametrize("task_class", task_class(), ids=lambda x: f"{x.config.task}")
-class TestNewTasks:
+class BaseTasks:
+    """
+    Base class for testing tasks
+    """
+
     def test_download(self, task_class: ConfigurableTask):
         task_class.download()
         assert task_class.dataset is not None
@@ -140,3 +154,57 @@ class TestNewTasks:
             for doc in arr
         ]
         assert len(requests) == limit if limit else True
+
+
+@pytest.mark.parametrize(
+    "task_class",
+    task_class(get_new_tasks_else_default()),
+    ids=lambda x: f"{x.config.task}",
+)
+class TestNewTasksElseDefault(BaseTasks):
+    """
+    Test class parameterized with a list of new/modified tasks
+    (or a set of default tasks if none have been modified)
+    """
+
+
+@pytest.mark.parametrize(
+    "task_class",
+    task_class(
+        ["arc_easy_unitxt"], tasks.TaskManager(include_path="./tests/testconfigs")
+    ),
+    ids=lambda x: f"{x.config.task}",
+)
+class TestUnitxtTasks(BaseTasks):
+    """
+    Test class for Unitxt tasks parameterized with a small custom
+    task as described here:
+      https://www.unitxt.ai/en/latest/docs/lm_eval.html
+    """
+
+    def test_check_training_docs(self, task_class: ConfigurableTask):
+        if task_class.has_training_docs():
+            assert task_class.dataset["train"] is not None
+
+    def test_check_validation_docs(self, task_class):
+        if task_class.has_validation_docs():
+            assert task_class.dataset["validation"] is not None
+
+    def test_check_test_docs(self, task_class):
+        task = task_class
+        if task.has_test_docs():
+            assert task.dataset["test"] is not None
+
+    def test_doc_to_text(self, task_class, limit: int):
+        task = task_class
+        arr = (
+            list(islice(task.test_docs(), limit))
+            if task.has_test_docs()
+            else list(islice(task.validation_docs(), limit))
+        )
+        _array = [task.doc_to_text(doc) for doc in arr]
+        if not task.multiple_input:
+            for x in _array:
+                assert isinstance(x, str)
+        else:
+            pass

--- a/tests/testconfigs/arc_easy_unitxt.yaml
+++ b/tests/testconfigs/arc_easy_unitxt.yaml
@@ -1,0 +1,3 @@
+task: arc_easy_unitxt
+include: ../../lm_eval/tasks/unitxt/unitxt
+recipe: card=cards.ai2_arc.arc_easy,template=templates.qa.multiple_choice.open.all


### PR DESCRIPTION
Cherry-pick of:

* https://github.com/opendatahub-io/lm-evaluation-harness/pull/30/commits/bf9351efcf409b3a6204273b0e5cb81ab7bc67f8
* https://github.com/opendatahub-io/lm-evaluation-harness/pull/30/commits/4f630b20796940265e66e821ff214e3b261e9513
* https://github.com/opendatahub-io/lm-evaluation-harness/pull/30/commits/51ecfaefd07d55b60e7ec0b02a4e040aab38f4ed
* https://github.com/opendatahub-io/lm-evaluation-harness/pull/30/commits/b860d1a9173d138bbdaa8ab5e8bd701bfcfe6c52

Additional commits to:

* Update `unitxt` version to be compatible with lm-evaluation-harness 0.4.8
* Pin dependencies