### PR TITLE
(fix): Update component name to match gitops

### DIFF
--- a/.tekton/ta-lmes-job-push.yaml
+++ b/.tekton/ta-lmes-job-push.yaml
@@ -13,9 +13,9 @@ metadata:
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-release
-    appstudio.openshift.io/component: lm-evaluation-harness
+    appstudio.openshift.io/component: ta-lmes-job
     pipelines.appstudio.openshift.io/type: build
-  name: lm-evaluation-harness-on-push
+  name: ta-lmes-job-on-push
   namespace: open-data-hub-tenant
 spec:
   params:
@@ -653,7 +653,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-lm-evaluation-harness
+    serviceAccountName: build-pipeline-ta-lmes-job
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The component name ie. ta-lmes-job has to match the one in the gitops.
This is the reason why the build was failing. It was trying to pull a wrongly named SA.
The easiest fix for this is to rename the tekton pipeline to match the one in the gitops.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
