### PR TITLE
chore: Bump release to 0.4.9rc0

### DIFF
--- a/.tekton/ta-lmes-job-push.yaml
+++ b/.tekton/ta-lmes-job-push.yaml
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/ta-lmes-job:v0.4.8
+    value: quay.io/opendatahub/ta-lmes-job:v0.4.9rc0
   - name: dockerfile
     value: Dockerfile.lmes-job
   - name: path-context


### PR DESCRIPTION
Bump Konflux image to `v0.4.9rc0`