### PR TITLE
fix(tasks):pin correct MMLUSR version

### DIFF
--- a/lm_eval/tasks/mmlusr/answer_only/_mmlusr_a_yml
+++ b/lm_eval/tasks/mmlusr/answer_only/_mmlusr_a_yml
@@ -1,4 +1,6 @@
 dataset_path: NiniCat/MMLU-SR
+dataset_kwargs:
+  revision: bd6827d2542e9d6cf1d58ce262ce0b9ad7742754
 test_split: test
 fewshot_split: train
 fewshot_config:

--- a/lm_eval/tasks/mmlusr/question_and_answer/_mmlusr_qna_yml
+++ b/lm_eval/tasks/mmlusr/question_and_answer/_mmlusr_qna_yml
@@ -1,4 +1,6 @@
 dataset_path: NiniCat/MMLU-SR
+dataset_kwargs:
+  revision: bd6827d2542e9d6cf1d58ce262ce0b9ad7742754
 test_split: test
 fewshot_split: train
 fewshot_config:

--- a/lm_eval/tasks/mmlusr/question_only/_mmlusr_q_yml
+++ b/lm_eval/tasks/mmlusr/question_only/_mmlusr_q_yml
@@ -1,4 +1,6 @@
 dataset_path: NiniCat/MMLU-SR
+dataset_kwargs:
+  revision: bd6827d2542e9d6cf1d58ce262ce0b9ad7742754
 test_split: test
 fewshot_split: train
 fewshot_config:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Addresses [RHOAIENG-33914](https://issues.redhat.com/browse/RHOAIENG-33914) by pinning correct revision version.

## Description
<!--- Describe your changes in detail -->
Tasks in MMLUSR group are broken because the dataset schema on HuggingFace has been updated without updating the code. This PR pins the correct version of the dataset.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by running an evaluation with MMLUSR tasks:
```
python3 -m lm_eval --model dummy --tasks mmlusr_answer_only,mmlusr_question_only,mmlusr --limit 1
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the MMLU-SR dataset to a specific revision across all variants (answer-only, question-only, Q&A) to stabilize content over time and improve reproducibility of results.
  * Splits, few-shot settings, metrics, and outputs remain unchanged.
  * No API or CLI changes.
  * No user action required; evaluations automatically use the pinned dataset version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->