### PR TITLE
feat: add oci.py script

### DIFF
--- a/.tekton/ta-lmes-job-push.yaml
+++ b/.tekton/ta-lmes-job-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "incubation"
+      == "release/odh-2.35"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-release
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/ta-lmes-job:latest
+    value: quay.io/opendatahub/ta-lmes-job:odh-2.35
   - name: dockerfile
     value: Dockerfile.lmes-job
   - name: path-context

--- a/.tekton/ta-lmes-job-push.yaml
+++ b/.tekton/ta-lmes-job-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "release/odh-2.35"
+      == "incubation"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-release
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/ta-lmes-job:odh-2.35
+    value: quay.io/opendatahub/ta-lmes-job:latest
   - name: dockerfile
     value: Dockerfile.lmes-job
   - name: path-context

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "unitxt==1.17.2",
     "jiwer==3.0.5",
     "boto3==1.36.11",
+    "olot==0.1.13",
 ]
 
 [tool.setuptools.packages.find]

--- a/requirements.txt
+++ b/requirements.txt
@@ -67,6 +67,7 @@ nvidia-cusparselt-cu12==0.6.2 ; python_version >= "3.10" and python_version < "3
 nvidia-nccl-cu12==2.21.5 ; python_version >= "3.10" and python_version < "3.13" and platform_system == "Linux" and platform_machine == "x86_64"
 nvidia-nvjitlink-cu12==12.4.127 ; python_version >= "3.10" and python_version < "3.13" and platform_system == "Linux" and platform_machine == "x86_64"
 nvidia-nvtx-cu12==12.4.127 ; python_version >= "3.10" and python_version < "3.13" and platform_system == "Linux" and platform_machine == "x86_64"
+olot==0.1.13 ; python_version >= "3.10" and python_version < "3.13"
 packaging==25.0 ; python_version >= "3.10" and python_version < "3.13"
 pandas==2.1.4 ; python_version >= "3.10" and python_version < "3.13"
 pathvalidate==3.2.3 ; python_version >= "3.10" and python_version < "3.13"

--- a/scripts/oci.py
+++ b/scripts/oci.py
@@ -44,7 +44,7 @@ def main():
     output_path = this_script_path.parent / ".." / "output"
     logger.info(f"Output path: {output_path}")
     if output_path.exists():
-        subdirs = [d for d in output_path.iterdir() if d.is_dir() and d.name != "lost+found"]
+        subdirs = [d for d in output_path.iterdir() if is_valid_subdir(d)]
         if len(subdirs) == 1:
             output_path = subdirs[0]
             logger.info(f"Output path updated to single subdirectory: {output_path}")
@@ -58,6 +58,11 @@ def main():
 
     logger.info("Transfering oci-layout of OCI Artifact (traces and results) to destination...")
     skopeo_push(oci_layout_path, oci_ref, skopeo_params("dest-"))
+
+
+def is_valid_subdir(path: Path) -> bool:
+    """Return True if this is a subdirectory we want to consider containing results and traces"""
+    return path.is_dir() and path.name != "lost+found"
 
 
 def skopeo_params(infix: str = ""):

--- a/scripts/oci.py
+++ b/scripts/oci.py
@@ -1,0 +1,101 @@
+import sys
+import os
+import logging
+import subprocess
+from pathlib import Path
+from olot.oci_artifact import create_simple_oci_artifact
+from olot.backend.skopeo import is_skopeo, skopeo_push, skopeo_inspect
+from olot.oci.oci_utils import get_descriptor_from_manifest
+
+logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
+logger = logging.getLogger(__name__)
+
+
+def main():
+    logger.debug("Command line arguments:")
+    for i, arg in enumerate(sys.argv):
+        logger.debug(f"  {i}: {arg}")
+
+    oci_ref = os.environ["OCI_REGISTRY"] + "/" + os.environ["OCI_REPOSITORY"] + ":" + os.environ["OCI_TAG"]
+    logger.info(f"oci_ref: {oci_ref}")
+
+    if not is_skopeo():
+        logger.error("Missing requirement: skopeo must be installed.")
+        exit -1
+    try:
+        result = subprocess.run(["skopeo", "--version"], capture_output=True, text=True, check=True)
+        logger.info(f"skopeo version: {result.stdout.strip()}")
+    except Exception as e:
+        logger.error(f"Failed to check skopeo version: {e}")
+        exit -1
+
+    subject = None
+    if os.environ.get("OCI_SUBJECT"):
+        if not os.environ["OCI_SUBJECT"].startswith(os.environ["OCI_REGISTRY"]) or os.environ["OCI_REPOSITORY"] not in os.environ["OCI_SUBJECT"]:
+            logger.error("OCI Subject/referrer must be in the same registry and repository")
+            exit -1
+        if "@" not in os.environ["OCI_SUBJECT"]:
+            logger.warning("Should prefer to use a digest based reference, instead of Tag reference")
+        manifest = skopeo_inspect("docker://"+os.environ["OCI_SUBJECT"], skopeo_params(""))
+        subject = get_descriptor_from_manifest(manifest)
+
+    # assumption is `output` directory sibling to this script containing the output traces (and results)
+    this_script_path = Path(__file__).resolve()
+    output_path = this_script_path.parent / ".." / "output"
+    logger.info(f"Output path: {output_path}")
+    if output_path.exists():
+        subdirs = [d for d in output_path.iterdir() if d.is_dir() and d.name != "lost+found"]
+        if len(subdirs) == 1:
+            output_path = subdirs[0]
+            logger.info(f"Output path updated to single subdirectory: {output_path}")
+    list_files(output_path)
+
+    oci_layout_path = Path("/tmp/oci-layout")
+    oci_layout_path.mkdir(parents=True, exist_ok=True)
+    create_simple_oci_artifact(output_path, oci_layout_path, subject=subject)
+    logger.info(f"/tmp/oci-layout: {oci_layout_path}")
+    list_files(oci_layout_path)
+
+    logger.info("Transfering oci-layout of OCI Artifact (traces and results) to destination...")
+    skopeo_push(oci_layout_path, oci_ref, skopeo_params("dest-"))
+
+
+def skopeo_params(infix: str = ""):
+    """
+    Common function to compute the Skopeo parameters
+    
+    :param infix: either leave empty or pass "dest-" to infix resulting skopeo parameters
+    :type infix: str
+    """
+    skopeo_params = []
+    docker_config_path = Path("/tmp/.docker/config.json")
+    if docker_config_path.exists():
+        logger.info(f"Contents of {docker_config_path}:")
+       # TODO remove below printing
+        with open(docker_config_path, 'r') as f:
+            logger.info(f.read())
+        skopeo_params.append("--"+infix+"authfile")
+        skopeo_params.append("/tmp/.docker/config.json")
+    else:
+        skopeo_params.append("--"+infix+"username")
+        skopeo_params.append(os.environ["OCI_USERNAME"])
+        skopeo_params.append("--"+infix+"password")
+        skopeo_params.append(os.environ["OCI_PASSWORD"])
+    if os.environ.get("OCI_VERIFY_SSL"):
+        skopeo_params.append("--"+infix+"tls-verify=false")
+    return skopeo_params
+
+
+def list_files(path):
+    logger.debug(f"\nRecursive listing of {path}:")
+    for root, _, files in os.walk(path):
+        level = root.count(os.sep)
+        indent = "." * level
+        logger.debug(f"{indent}{os.path.basename(root)}")
+        subindent = "." * (level + 1)
+        for f in files:
+            logger.debug(f"{subindent}{f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/oci.py
+++ b/scripts/oci.py
@@ -70,10 +70,6 @@ def skopeo_params(infix: str = ""):
     skopeo_params = []
     docker_config_path = Path("/tmp/.docker/config.json")
     if docker_config_path.exists():
-        logger.info(f"Contents of {docker_config_path}:")
-       # TODO remove below printing
-        with open(docker_config_path, 'r') as f:
-            logger.info(f.read())
         skopeo_params.append("--"+infix+"authfile")
         skopeo_params.append("/tmp/.docker/config.json")
     else:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add oci.py script so to make persistent storage with OCI (traces and any other result files)

## How Has This Been Tested?
Create an OCI Connection such as:

<img width="2032" height="1192" alt="Screenshot 2025-11-27 at 11 45 31" src="https://github.com/user-attachments/assets/cc284d07-b478-4ce5-b3bb-a1cf4e1fa1dc" />

Using `dev/oci` feature branch for the Driver/Controller, create a LMEval CR such ~like:

```yaml
apiVersion: trustyai.opendatahub.io/v1alpha1
kind: LMEvalJob
metadata:
  name: test-oci-job
  namespace: ds-prj1
spec:
  allowOnline: true
  allowCodeExecution: true
  model: hf
  modelArgs:
  - name: pretrained
    value: EleutherAI/pythia-70m
  taskList:
    taskNames:
    - unfair_tos # arc_easy, unfair_tos
  logSamples: true
  limit: "5"
  outputs:
    pvcManaged: 
      size: 5Gi
    oci:
      registry:
        name: my-oci-credentials
        key: OCI_HOST
      repository: mmortari/demo20251016-lmeh-olot
      tag: test20251127v1
      dockerConfigJson:
        name: my-oci-credentials
        key: .dockerconfigjson
```

Results in the script invocation:

<img width="2032" height="1192" alt="Screenshot 2025-11-27 at 11 37 03" src="https://github.com/user-attachments/assets/0e894f1b-ecf5-40eb-8e63-8ae6aae96651" />

(the below debugging will be removed on the PR)

<img width="2032" height="1192" alt="Screenshot 2025-11-27 at 11 37 10" src="https://github.com/user-attachments/assets/e54c45ab-ab8f-4165-a52b-b7977dc232c8" />

Results in a persisted artifact on OCI:

<img width="1544" height="819" alt="image" src="https://github.com/user-attachments/assets/b79e045b-952b-43f5-9cdc-bf431e72ed54" />

containing the expected files. Please notice this is a CRI-O valid ImageVolume mount.

Now create a second CR with the resulting Artifact above as the Subject, to demonstrate 'lineage":

```yaml
apiVersion: trustyai.opendatahub.io/v1alpha1
kind: LMEvalJob
metadata:
  name: test-oci-job
  namespace: ds-prj1
spec:
  allowOnline: true
  allowCodeExecution: true
  model: hf
  modelArgs:
  - name: pretrained
    value: EleutherAI/pythia-70m
  taskList:
    taskNames:
    - unfair_tos # arc_easy, unfair_tos
  logSamples: true
  limit: "5"
  outputs:
    pvcManaged: 
      size: 5Gi
    oci:
      registry:
        name: my-oci-credentials
        key: OCI_HOST
      repository: mmortari/demo20251016-lmeh-olot
      tag: test20251127v2
      subject: "quay.io/mmortari/demo20251016-lmeh-olot:test20251127v1"
      dockerConfigJson:
        name: my-oci-credentials
        key: .dockerconfigjson
```

resulting in:

<img width="1920" height="1080" alt="Screenshot 2025-11-27 at 11 53 51 (2)" src="https://github.com/user-attachments/assets/542ba1e3-0be5-42cc-90e0-8b2fd1344696" />

.
So that in this case previous `...v1` stand-in for what could be a Model, a generic Asset,
while now the `...v2` is the resulting persisted Eval, that is _referring_ the original asset being measured:

<img width="1920" height="1080" alt="Screenshot 2025-11-27 at 11 56 05 (2)" src="https://github.com/user-attachments/assets/9cf0c4b3-baed-49ee-b17b-c1c7415e2ed1" />

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
👉 please squash on merge
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
