### PR TITLE
fix: align job results and OCI artifacts with new spec

### DIFF
--- a/main.py
+++ b/main.py
@@ -300,6 +300,7 @@ class LMEvalAdapter(FrameworkAdapter):
             job_results = JobResults(
                 id=job_id,
                 benchmark_id=benchmark_id,
+                benchmark_index=config.benchmark_index,
                 model_name=model_name,
                 results=evaluation_results,
                 overall_score=overall_score,
@@ -339,26 +340,27 @@ class LMEvalAdapter(FrameworkAdapter):
                     default=str,
                 )
 
-            # Create OCI artifact
-            oci_spec = OCIArtifactSpec(
-                files=[results_file],
-                base_path=output_dir,
-                title=f"LMEval Results - {benchmark_id}",
-                description=f"Evaluation results for {model_name} on {benchmark_id}",
-                annotations={
-                    "org.opencontainers.image.created": datetime.now(UTC).isoformat(),
-                    "org.evalhub.benchmark": benchmark_id,
-                    "org.evalhub.model": model_name,
-                    "org.evalhub.job_id": job_id,
-                },
-                id=job_id,
-                benchmark_id=benchmark_id,
-                model_name=model_name,
-            )
-
-            oci_result = callbacks.create_oci_artifact(oci_spec)
-            job_results.oci_artifact = oci_result
-            logger.info(f"OCI artifact created: {oci_result.reference}")
+            # Create OCI artifact (only when exports are configured)
+            oci_exports = config.exports.oci if config.exports else None
+            if oci_exports is not None:
+                coords = oci_exports.coordinates.model_copy(deep=True)
+                coords.annotations.update(
+                    {
+                        "org.opencontainers.image.created": datetime.now(UTC).isoformat(),
+                        "org.evalhub.benchmark": benchmark_id,
+                        "org.evalhub.model": model_name,
+                        "org.evalhub.job_id": job_id,
+                    }
+                )
+                oci_spec = OCIArtifactSpec(
+                    files_path=output_dir,
+                    coordinates=coords,
+                )
+                oci_result = callbacks.create_oci_artifact(oci_spec)
+                job_results.oci_artifact = oci_result
+                logger.info(f"OCI artifact created: {oci_result.reference}")
+            else:
+                logger.info("No OCI exports configured; skipping artifact persistence")
 
             # Return results (will be reported by entrypoint)
             return job_results


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Include benchmark_index in JobResults as per new SDK schema
- Build OCIArtifactSpec as per new SDK schema
- Skip OCI persistence when exports are not configured

## How Has This Been Tested?
```
Requesting API:  80%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▍                             | 8/10 [00:11<00:02,  1.40s/it]2026-03-04 10:58:56,027 - lm_eval.models.api_models - INFO - Tokenized requests are disabled. Context + generation length is not checked.
Requesting API:  90%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▏              | 9/10 [00:12<00:01,  1.26s/it]2026-03-04 10:58:56,973 - lm_eval.models.api_models - INFO - Tokenized requests are disabled. Context + generation length is not checked.
Requesting API: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:13<00:00,  1.32s/it]
2026-03-04 10:58:59,302 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/63968f48-de90-40c7-8cb8-8c89052ed486/events "HTTP/1.1 204 No Content"
2026-03-04 10:58:59,306 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/63968f48-de90-40c7-8cb8-8c89052ed486/events "HTTP/1.1 204 No Content"
2026-03-04 10:58:59,307 - __main__ - INFO - No OCI exports configured; skipping artifact persistence
2026-03-04 10:58:59,307 - __main__ - INFO - ================================================================================
2026-03-04 10:58:59,307 - __main__ - INFO - Evaluation completed successfully
2026-03-04 10:58:59,307 - __main__ - INFO - Overall score: None
2026-03-04 10:58:59,307 - __main__ - INFO - Examples evaluated: 20
2026-03-04 10:58:59,307 - __main__ - INFO - Duration: 25.45s
2026-03-04 10:58:59,307 - __main__ - INFO - ================================================================================
2026-03-04 10:58:59,310 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/63968f48-de90-40c7-8cb8-8c89052ed486/events "HTTP/1.1 204 No Content"
2026-03-04 10:58:59,310 - evalhub.adapter.callbacks - INFO - Results reported to evalhub | Metrics: 0 | Score: None
2026-03-04 10:58:59,310 - evalhub.adapter.callbacks - INFO - Job 63968f48-de90-40c7-8cb8-8c89052ed486 completed | Benchmark: gsm8k | Model: qwen2.5-1.5b-instruct.gguf | Score: None | Examples: 20 | Duration: 25.45s
(.venv) scheruku@scheruku-mac lm-evaluation-harness 
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OCI artifact persistence is now conditional based on export configuration. When OCI exports are configured, artifacts are created with enhanced metadata including creation timestamp and identifiers. When not configured, artifact creation is skipped.

* **Improvements**
  * Benchmark index now included in job results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->