### PR TITLE
cherry-pick:avoid global CA overrides

### DIFF
--- a/lm_eval/models/api_models.py
+++ b/lm_eval/models/api_models.py
@@ -4,6 +4,8 @@ import copy
 import itertools
 import json
 import logging
+import ssl
+from pathlib import Path
 from functools import cached_property
 from typing import (
     Any,
@@ -79,7 +81,7 @@ class TemplateAPI(TemplateLM):
         trust_remote_code: bool = False,
         revision: Optional[str] = "main",
         use_fast_tokenizer: bool = True,
-        verify_certificate: bool = True,
+        verify_certificate: Union[bool, str, Path] = True,
         eos_string: str = None,
         # timeout in seconds
         timeout: int = 300,
@@ -127,6 +129,30 @@ class TemplateAPI(TemplateLM):
         self.tokenized_requests = tokenized_requests
         self.max_retries = int(max_retries)
         self.verify_certificate = verify_certificate
+        self._ssl_context = None
+        if isinstance(verify_certificate, (str, Path)):
+            raw_path = Path(verify_certificate)
+            if raw_path.is_symlink():
+                raise ValueError(
+                    f"verify_certificate path must not be a symlink: {raw_path}"
+                )
+            try:
+                resolved_path = raw_path.resolve(strict=True)
+            except FileNotFoundError as exc:
+                raise ValueError(
+                    f"verify_certificate path does not exist: {raw_path}"
+                ) from exc
+            if not resolved_path.is_file():
+                raise ValueError(
+                    f"verify_certificate path must be a regular file: {resolved_path}"
+                )
+            ca_path = str(resolved_path)
+            self.verify_certificate = ca_path
+            self._ssl_context = ssl.create_default_context(cafile=ca_path)
+        elif not isinstance(verify_certificate, bool):
+            raise TypeError(
+                "verify_certificate must be a bool or a path to a CA bundle"
+            )
         self._eos_string = eos_string
         self.timeout = int(timeout)
 
@@ -475,7 +501,10 @@ class TemplateAPI(TemplateLM):
         **kwargs,
     ) -> Union[List[List[str]], List[List[Tuple[float, bool]]]]:
         ctxlens = ctxlens if ctxlens else [None] * len(requests)
-        conn = TCPConnector(limit=self._concurrent, ssl=self.verify_certificate)
+        conn = TCPConnector(
+            limit=self._concurrent,
+            ssl=self._ssl_context if self._ssl_context is not None else self.verify_certificate,
+        )
         async with ClientSession(
             connector=conn, timeout=ClientTimeout(total=self.timeout)
         ) as session:

--- a/main.py
+++ b/main.py
@@ -172,10 +172,6 @@ class LMEvalAdapter(FrameworkAdapter):
                 if auth_value.startswith("Bearer "):
                     token = auth_value.replace("Bearer ", "").strip()
                     os.environ["OPENAI_API_KEY"] = token
-            if creds.ca_cert_path:
-                # Note: this sets a global CA bundle for requests.
-                os.environ["REQUESTS_CA_BUNDLE"] = creds.ca_cert_path
-                os.environ["SSL_CERT_FILE"] = creds.ca_cert_path
             job_id = config.id
             benchmark_id = config.benchmark_id
             model_name = config.model.name
@@ -190,6 +186,9 @@ class LMEvalAdapter(FrameworkAdapter):
             random_seed = int(benchmark_cfg.get("random_seed", 42))
 
             model_backend, model_args, gen_kwargs = build_lmeval_config(config)
+            if creds.ca_cert_path:
+                # Pass model-specific CA path without overriding global trust store.
+                model_args["verify_certificate"] = creds.ca_cert_path
 
             # Phase 1: Initialization
             callbacks.report_status(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Avoid setting global CA bundle env vars from the model secret.
- Pass the model CA directly to the API model via verify_certificate for model-only TLS verification.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Local testing by hitting a model which is configured with https and self signed cert.
```
EVALHUB_JOB_SPEC_PATH=/tmp/job.json python main.py                 
2026-03-09 22:30:06,224 - evalhub.adapter.models.adapter - INFO - Loading job spec from /tmp/job.json
2026-03-09 22:30:06,224 - __main__ - INFO - LMEval adapter initialized
2026-03-09 22:30:06,224 - __main__ - INFO - ================================================================================
2026-03-09 22:30:06,224 - __main__ - INFO - LMEval EvalHub Adapter
2026-03-09 22:30:06,224 - __main__ - INFO - ================================================================================
2026-03-09 22:30:06,224 - __main__ - INFO - Loaded job spec from: /tmp/job.json
2026-03-09 22:30:06,224 - __main__ - INFO - Job spec configuration:
2026-03-09 22:30:06,224 - __main__ - INFO -   Job ID: af0ea77d-6297-47cf-8859-aade6ea270a8
2026-03-09 22:30:06,224 - __main__ - INFO -   Benchmark: gsm8k
2026-03-09 22:30:06,224 - __main__ - INFO -   Model: gpt2
2026-03-09 22:30:06,224 - __main__ - INFO -   Examples: 10
2026-03-09 22:30:06,224 - __main__ - INFO -   Few-shot: None
2026-03-09 22:30:06,225 - __main__ - INFO - ================================================================================
2026-03-09 22:30:06,225 - __main__ - INFO - Callback URL: http://localhost:8080
2026-03-09 22:30:06,225 - __main__ - INFO - Provider ID: lm_evaluation_harness
2026-03-09 22:30:06,225 - __main__ - INFO - OCI registry auth config present: False
2026-03-09 22:30:06,225 - __main__ - INFO - OCI insecure: False
2026-03-09 22:30:06,225 - __main__ - INFO - EvalHub insecure: False
2026-03-09 22:30:06,225 - __main__ - INFO - ================================================================================
2026-03-09 22:30:06,257 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/af0ea77d-6297-47cf-8859-aade6ea270a8/events "HTTP/1.1 204 No Content"
2026-03-09 22:30:06,258 - __main__ - INFO - Job ID: af0ea77d-6297-47cf-8859-aade6ea270a8
2026-03-09 22:30:06,258 - __main__ - INFO - Model: gpt2
2026-03-09 22:30:06,258 - __main__ - INFO - Benchmark: gsm8k
2026-03-09 22:30:06,258 - __main__ - INFO - Examples limit: 10
2026-03-09 22:30:06,258 - __main__ - INFO - Few-shot: 0
2026-03-09 22:30:06,258 - __main__ - INFO - Device: cpu (forced)
2026-03-09 22:30:06,258 - __main__ - INFO - Model backend: local-completions
2026-03-09 22:30:06,260 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/af0ea77d-6297-47cf-8859-aade6ea270a8/events "HTTP/1.1 204 No Content"
2026-03-09 22:30:07,220 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/af0ea77d-6297-47cf-8859-aade6ea270a8/events "HTTP/1.1 204 No Content"
2026-03-09 22:30:07,222 - lm_eval.evaluator - INFO - Setting random seed to 42 | Setting numpy seed to 42 | Setting torch manual seed to 42 | Setting fewshot manual seed to 1234
2026-03-09 22:30:07,222 - lm_eval.evaluator - INFO - Initializing local-completions model, with arguments: {'model': 'gpt2', 'base_url': 'https://vllm-route-prabhu.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1/completions', 'tokenizer_backend': 'huggingface', 'tokenizer': 'google/flan-t5-small', 'tokenized_requests': False, 'batch_size': 1, 'timeout': 300, 'verify_certificate': '/tmp/model/ca_cert'}
2026-03-09 22:30:07,222 - lm_eval.models.api_models - INFO - Using max length 2048 - 1
2026-03-09 22:30:07,222 - lm_eval.models.api_models - INFO - Concurrent requests are disabled. To enable concurrent requests, set `num_concurrent` > 1.
2026-03-09 22:30:07,222 - lm_eval.models.api_models - INFO - Using tokenizer huggingface
2026-03-09 22:30:15,562 - lm_eval.evaluator - WARNING - Overwriting default num_fewshot of gsm8k from 5 to 0
2026-03-09 22:30:15,562 - lm_eval.api.task - INFO - Building contexts for gsm8k on rank 0...
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:00<00:00, 7305.88it/s]
2026-03-09 22:30:15,564 - lm_eval.evaluator - INFO - Running generate_until requests
Requesting API:   0%|                                                                                                                                                                         | 0/10 [00:00<?, ?it/s]2026-03-09 22:30:15,564 - lm_eval.models.api_models - INFO - Tokenized requests are disabled. Context + generation length is not checked.
Requesting API:  10%|████████████████                                                                                                                                                 | 1/10 [00:01<00:10,  1.12s/it]2026-03-09 22:30:16,686 - lm_eval.models.api_models - INFO - Tokenized requests are disabled. Context + generation length is not checked.
Requesting API:  20%|████████████████████████████████▏                                                                                                                                | 2/10 [00:02<00:08,  1.11s/it]2026-03-09 22:30:17,793 - lm_eval.models.api_models - INFO - Tokenized requests are disabled. Context + generation length is not checked.
Requesting API:  30%|████████████████████████████████████████████████▎                                                                                                                | 3/10 [00:03<00:07,  1.10s/it]2026-03-09 22:30:18,886 - lm_eval.models.api_models - INFO - Tokenized requests are disabled. Context + generation length is not checked.
Requesting API:  40%|████████████████████████████████████████████████████████████████▍                                                                                                | 4/10 [00:04<00:06,  1.07s/it]2026-03-09 22:30:19,901 - lm_eval.models.api_models - INFO - Tokenized requests are disabled. Context + generation length is not checked.
Requesting API:  50%|████████████████████████████████████████████████████████████████████████████████▌                                                                                | 5/10 [00:05<00:05,  1.07s/it]2026-03-09 22:30:20,970 - lm_eval.models.api_models - INFO - Tokenized requests are disabled. Context + generation length is not checked.
Requesting API:  60%|████████████████████████████████████████████████████████████████████████████████████████████████▌                                                                | 6/10 [00:06<00:04,  1.08s/it]2026-03-09 22:30:22,069 - lm_eval.models.api_models - INFO - Tokenized requests are disabled. Context + generation length is not checked.
Requesting API:  70%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████▋                                                | 7/10 [00:07<00:03,  1.10s/it]2026-03-09 22:30:23,215 - lm_eval.models.api_models - INFO - Tokenized requests are disabled. Context + generation length is not checked.
Requesting API:  80%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▊                                | 8/10 [00:08<00:02,  1.12s/it]2026-03-09 22:30:24,391 - lm_eval.models.api_models - INFO - Tokenized requests are disabled. Context + generation length is not checked.
Requesting API:  90%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▉                | 9/10 [00:09<00:01,  1.09s/it]2026-03-09 22:30:25,407 - lm_eval.models.api_models - INFO - Tokenized requests are disabled. Context + generation length is not checked.
Requesting API: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:10<00:00,  1.06s/it]
2026-03-09 22:30:26,951 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/af0ea77d-6297-47cf-8859-aade6ea270a8/events "HTTP/1.1 204 No Content"
2026-03-09 22:30:26,954 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/af0ea77d-6297-47cf-8859-aade6ea270a8/events "HTTP/1.1 204 No Content"
2026-03-09 22:30:26,954 - __main__ - INFO - No OCI exports configured; skipping artifact persistence
2026-03-09 22:30:26,955 - __main__ - INFO - ================================================================================
2026-03-09 22:30:26,955 - __main__ - INFO - Evaluation completed successfully
2026-03-09 22:30:26,955 - __main__ - INFO - Overall score: None
2026-03-09 22:30:26,955 - __main__ - INFO - Examples evaluated: 20
2026-03-09 22:30:26,955 - __main__ - INFO - Duration: 20.70s
2026-03-09 22:30:26,955 - __main__ - INFO - ================================================================================
2026-03-09 22:30:26,957 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/af0ea77d-6297-47cf-8859-aade6ea270a8/events "HTTP/1.1 204 No Content"
2026-03-09 22:30:26,957 - evalhub.adapter.callbacks - INFO - Results reported to evalhub | Metrics: 0 | Score: None
2026-03-09 22:30:26,957 - evalhub.adapter.callbacks - INFO - Job af0ea77d-6297-47cf-8859-aade6ea270a8 completed | Benchmark: gsm8k | Model: gpt2 | Score: None | Examples: 20 | Duration: 20.70s

```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
