### PR TITLE
fix: resolve CA cert path so symlinks work for lm_eval

### DIFF
--- a/main.py
+++ b/main.py
@@ -187,8 +187,8 @@ class LMEvalAdapter(FrameworkAdapter):
 
             model_backend, model_args, gen_kwargs = build_lmeval_config(config)
             if creds.ca_cert_path:
-                # Pass model-specific CA path without overriding global trust store.
-                model_args["verify_certificate"] = creds.ca_cert_path
+                # Resolve to a real path so lm_eval accepts it (K8s secret volume mounts expose keys as symlinks).
+                model_args["verify_certificate"] = os.path.realpath(creds.ca_cert_path)
 
             # Phase 1: Initialization
             callbacks.report_status(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The model-auth secret (with keys such as api-key and ca_cert) is mounted in the pod so that each key is a symlink to the real file. lm_eval rejects symlink paths for verify_certificate, so the CA path was rejected. The fix is to resolve the path with os.path.realpath() before passing it to lm_eval, so it receives the real file path and accepts it.

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally:
```
2026-03-12 13:04:12,754 - evalhub.adapter.models.adapter - INFO - Loading job spec from /Users/scheruku/job.json
2026-03-12 13:04:12,755 - __main__ - INFO - LMEval adapter initialized
2026-03-12 13:04:12,755 - __main__ - INFO - ================================================================================
2026-03-12 13:04:12,755 - __main__ - INFO - LMEval EvalHub Adapter
2026-03-12 13:04:12,755 - __main__ - INFO - ================================================================================
2026-03-12 13:04:12,755 - __main__ - INFO - Loaded job spec from: /Users/scheruku/job.json
2026-03-12 13:04:12,755 - __main__ - INFO - Job spec configuration:
2026-03-12 13:04:12,755 - __main__ - INFO -   Job ID: 7aa06b8f-c460-4a2a-b748-0d55ae01849a
2026-03-12 13:04:12,755 - __main__ - INFO -   Benchmark: gsm8k
2026-03-12 13:04:12,755 - __main__ - INFO -   Model: gpt2
2026-03-12 13:04:12,755 - __main__ - INFO -   Examples: 10
2026-03-12 13:04:12,755 - __main__ - INFO -   Few-shot: None
2026-03-12 13:04:12,755 - __main__ - INFO - ================================================================================
2026-03-12 13:04:12,755 - __main__ - INFO - Callback URL: http://localhost:8080
2026-03-12 13:04:12,755 - __main__ - INFO - Provider ID: lm_evaluation_harness
2026-03-12 13:04:12,755 - __main__ - INFO - OCI registry auth config present: False
2026-03-12 13:04:12,755 - __main__ - INFO - OCI insecure: False
2026-03-12 13:04:12,755 - __main__ - INFO - EvalHub insecure: False
2026-03-12 13:04:12,755 - __main__ - INFO - ================================================================================
2026-03-12 13:04:12,776 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/7aa06b8f-c460-4a2a-b748-0d55ae01849a/events "HTTP/1.1 204 No Content"
2026-03-12 13:04:12,776 - __main__ - INFO - Job ID: 7aa06b8f-c460-4a2a-b748-0d55ae01849a
2026-03-12 13:04:12,776 - __main__ - INFO - Model: gpt2
2026-03-12 13:04:12,776 - __main__ - INFO - Benchmark: gsm8k
2026-03-12 13:04:12,776 - __main__ - INFO - Examples limit: 10
2026-03-12 13:04:12,776 - __main__ - INFO - Few-shot: 0
2026-03-12 13:04:12,776 - __main__ - INFO - Device: cpu (forced)
2026-03-12 13:04:12,776 - __main__ - INFO - Model backend: local-completions
2026-03-12 13:04:12,780 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/7aa06b8f-c460-4a2a-b748-0d55ae01849a/events "HTTP/1.1 204 No Content"
2026-03-12 13:04:13,504 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/7aa06b8f-c460-4a2a-b748-0d55ae01849a/events "HTTP/1.1 204 No Content"
2026-03-12 13:04:13,505 - lm_eval.evaluator - INFO - Setting random seed to 42 | Setting numpy seed to 42 | Setting torch manual seed to 42 | Setting fewshot manual seed to 1234
2026-03-12 13:04:13,505 - lm_eval.evaluator - INFO - Initializing local-completions model, with arguments: {'model': 'gpt2', 'base_url': 'https://vllm-route-prabhu.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1/completions', 'tokenizer_backend': 'huggingface', 'tokenizer': 'google/flan-t5-small', 'tokenized_requests': False, 'batch_size': 1, 'timeout': 300, 'verify_certificate': '/private/var/run/secrets/model/ca_cert.real'}
2026-03-12 13:04:13,505 - lm_eval.models.api_models - INFO - Using max length 2048 - 1
2026-03-12 13:04:13,505 - lm_eval.models.api_models - INFO - Concurrent requests are disabled. To enable concurrent requests, set `num_concurrent` > 1.
2026-03-12 13:04:13,505 - lm_eval.models.api_models - INFO - Using tokenizer huggingface
2026-03-12 13:04:23,023 - lm_eval.evaluator - WARNING - Overwriting default num_fewshot of gsm8k from 5 to 0
2026-03-12 13:04:23,024 - lm_eval.api.task - INFO - Building contexts for gsm8k on rank 0...
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:00<00:00, 6984.69it/s]
2026-03-12 13:04:23,025 - lm_eval.evaluator - INFO - Running generate_until requests
Requesting API:   0%|                                                                                                                                                                         | 0/10 [00:00<?, ?it/s]2026-03-12 13:04:23,026 - lm_eval.models.api_models - INFO - Tokenized requests are disabled. Context + generation length is not checked.
Requesting API:  10%|████████████████                                                                                                                                                 | 1/10 [00:01<00:09,  1.00s/it]2026-03-12 13:04:24,029 - lm_eval.models.api_models - INFO - Tokenized requests are disabled. Context + generation length is not checked.
Requesting API:  20%|████████████████████████████████▏                                                                                                                                | 2/10 [00:02<00:08,  1.06s/it]2026-03-12 13:04:25,132 - lm_eval.models.api_models - INFO - Tokenized requests are disabled. Context + generation length is not checked.
Requesting API:  30%|████████████████████████████████████████████████▎                                                                                                                | 3/10 [00:03<00:07,  1.10s/it]2026-03-12 13:04:26,267 - lm_eval.models.api_models - INFO - Tokenized requests are disabled. Context + generation length is not checked.
Requesting API:  40%|████████████████████████████████████████████████████████████████▍                                                                                                | 4/10 [00:04<00:06,  1.11s/it]2026-03-12 13:04:27,398 - lm_eval.models.api_models - INFO - Tokenized requests are disabled. Context + generation length is not checked.
Requesting API:  50%|████████████████████████████████████████████████████████████████████████████████▌                                                                                | 5/10 [00:05<00:05,  1.07s/it]2026-03-12 13:04:28,397 - lm_eval.models.api_models - INFO - Tokenized requests are disabled. Context + generation length is not checked.
Requesting API:  60%|████████████████████████████████████████████████████████████████████████████████████████████████▌                                                                | 6/10 [00:06<00:04,  1.06s/it]2026-03-12 13:04:29,451 - lm_eval.models.api_models - INFO - Tokenized requests are disabled. Context + generation length is not checked.
Requesting API:  70%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████▋                                                | 7/10 [00:07<00:03,  1.04s/it]2026-03-12 13:04:30,446 - lm_eval.models.api_models - INFO - Tokenized requests are disabled. Context + generation length is not checked.
Requesting API:  80%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▊                                | 8/10 [00:08<00:02,  1.05s/it]2026-03-12 13:04:31,510 - lm_eval.models.api_models - INFO - Tokenized requests are disabled. Context + generation length is not checked.
Requesting API:  90%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▉                | 9/10 [00:09<00:01,  1.07s/it]2026-03-12 13:04:32,634 - lm_eval.models.api_models - INFO - Tokenized requests are disabled. Context + generation length is not checked.
Requesting API: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:10<00:00,  1.04s/it]
2026-03-12 13:04:33,970 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/7aa06b8f-c460-4a2a-b748-0d55ae01849a/events "HTTP/1.1 204 No Content"
2026-03-12 13:04:33,973 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/7aa06b8f-c460-4a2a-b748-0d55ae01849a/events "HTTP/1.1 204 No Content"
2026-03-12 13:04:33,974 - __main__ - INFO - No OCI exports configured; skipping artifact persistence
2026-03-12 13:04:33,974 - __main__ - INFO - ================================================================================
2026-03-12 13:04:33,974 - __main__ - INFO - Evaluation completed successfully
2026-03-12 13:04:33,974 - __main__ - INFO - Overall score: None
2026-03-12 13:04:33,974 - __main__ - INFO - Examples evaluated: 20
2026-03-12 13:04:33,974 - __main__ - INFO - Duration: 21.20s
2026-03-12 13:04:33,974 - __main__ - INFO - ================================================================================
2026-03-12 13:04:33,978 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/7aa06b8f-c460-4a2a-b748-0d55ae01849a/events "HTTP/1.1 204 No Content"
2026-03-12 13:04:33,978 - evalhub.adapter.callbacks - INFO - Results reported to evalhub | Metrics: 0 | Score: None
2026-03-12 13:04:33,978 - evalhub.adapter.callbacks - INFO - Job 7aa06b8f-c460-4a2a-b748-0d55ae01849a completed | Benchmark: gsm8k | Model: gpt2 | Score: None | Examples: 20 | Duration: 21.20s
(.venv) scheruku@scheruku-mac lm-evaluation-harness % ls -l /var/run/secrets/model 
total 16
lrwxr-xr-x  1 root  daemon    12 12 Mar 13:00 api-key -> api-key.real
-rw-r--r--  1 root  daemon    19 12 Mar 12:54 api-key.real
lrwxr-xr-x  1 root  daemon    12 12 Mar 13:00 ca_cert -> ca_cert.real
-rw-r--r--  1 root  daemon  1834 12 Mar 12:52 ca_cert.real

```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved CA certificate path resolution for OpenAI-compatible endpoints. The system now correctly handles symlink-based certificate paths—such as those used in Kubernetes secret volumes and other containerized deployments—ensuring proper certificate verification and enhancing compatibility across cloud-native environments and container orchestration platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->