### PR TITLE
[RHOAIENG-48020] Update final image stage to use python312-minimal, bump to python3

### DIFF
--- a/Dockerfile.lmes-job
+++ b/Dockerfile.lmes-job
@@ -2,7 +2,7 @@
 # Stage 1 Base builder image with common tooling
 ###############################################################
 
-FROM registry.access.redhat.com/ubi9/python-311:latest AS builder
+FROM registry.access.redhat.com/ubi9/python-312:latest AS builder
 USER root
 
 ENV TORCH_VERSION=2.6.0
@@ -169,7 +169,7 @@ RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
 # Stage 5 to build Final Image
 ###############################################################
 
-FROM builder AS final-build
+FROM registry.access.redhat.com/ubi9/python-312-minimal:latest AS final-build
 USER root
 
 ARG TARGETARCH
@@ -214,7 +214,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Install the package
 RUN pip install --no-cache-dir --no-deps -e .
 
-USER default
+USER 1001
 
 RUN mkdir /opt/app-root/src/hf_home && chmod g+rwx /opt/app-root/src/hf_home                     && \
     mkdir /opt/app-root/src/output && chmod g+rwx /opt/app-root/src/output                       && \


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

A requirement came down to use -minimal variants for all RHOAI component images (in their final build stage). https://redhat.atlassian.net/browse/RHOAIENG-48020

In this case, the red hat catalog doesn't offer a ubi9/python-311-minimal image, due to the fact that the ubi9 app stream for python 3.11 goes EOL in May 2026 (https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle#rhel9_application_streams). 

I am proposing a bump to python 3.12, which appears to be in the limits specified by the pyproject.toml. 

<!--- Describe your changes in detail -->

## How Has This Been Tested?
I have sucesfully built an image with these changes locally, but not have tested (and am not sure how to) any functionality.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container runtime to Python 3.12.
  * Switched the final image to a Python 3.12-based runtime.
  * Adjusted container user configuration used during image build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->