### PR TITLE
fix(cve): CVE-2024-35515 - sqlitedict insecure deserialization

### DIFF
--- a/lm_eval/api/model.py
+++ b/lm_eval/api/model.py
@@ -242,7 +242,12 @@ class CachingLM:
         self.cache_db = cache_db
         if os.path.dirname(cache_db):
             os.makedirs(os.path.dirname(cache_db), exist_ok=True)
-        self.dbdict = SqliteDict(cache_db, autocommit=True)
+        self.dbdict = SqliteDict(
+            cache_db,
+            autocommit=True,
+            encode=json.dumps,
+            decode=json.loads,
+        )
 
         # add hook to lm
         lm.set_cache_hook(self.get_cache_hook())


### PR DESCRIPTION
- Replace default pickle serializer with json in SqliteDict instantiation
- Uses encode=json.dumps, decode=json.loads to prevent arbitrary code execution via crafted cache files
- json module already imported in the file
- Note: existing pickle-based cache files will need to be regenerated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved cache serialization handling for model evaluation operations to enhance reliability and consistency when storing and retrieving cached data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->