### PR TITLE
feat(lmeval): add offline mode support for disconnected evaluations

### DIFF
--- a/main.py
+++ b/main.py
@@ -176,7 +176,9 @@ class LMEvalAdapter(FrameworkAdapter):
                         "populates the directory before the adapter starts."
                     )
                 os.environ["HF_HOME"] = test_data_dir
+                os.environ["HF_HUB_OFFLINE"] = "1"
                 os.environ["HF_DATASETS_OFFLINE"] = "1"
+                os.environ["HF_EVALUATE_OFFLINE"] = "1"
                 os.environ["TRANSFORMERS_OFFLINE"] = "1"
                 logger.info(
                     "Offline mode enabled: HF_HOME=%s, downloads disabled",

--- a/main.py
+++ b/main.py
@@ -164,6 +164,19 @@ class LMEvalAdapter(FrameworkAdapter):
         start_time = time.time()
 
         try:
+            # When offline mode is enabled, configure HuggingFace libraries to
+            # use only local data from /test_data (populated by the init container
+            # from S3 via test_data_ref).  This covers both datasets and tokenizers.
+            if config.parameters.get("offline"):
+                test_data_dir = "/test_data"
+                os.environ["HF_HOME"] = test_data_dir
+                os.environ["HF_DATASETS_OFFLINE"] = "1"
+                os.environ["TRANSFORMERS_OFFLINE"] = "1"
+                logger.info(
+                    "Offline mode enabled: HF_HOME=%s, downloads disabled",
+                    test_data_dir,
+                )
+
             creds = resolve_model_credentials()
             if creds.api_key:
                 os.environ["OPENAI_API_KEY"] = creds.api_key

--- a/main.py
+++ b/main.py
@@ -169,6 +169,12 @@ class LMEvalAdapter(FrameworkAdapter):
             # from S3 via test_data_ref).  This covers both datasets and tokenizers.
             if config.parameters.get("offline"):
                 test_data_dir = "/test_data"
+                if not os.path.isdir(test_data_dir):
+                    raise RuntimeError(
+                        f"Offline mode requested but {test_data_dir} does not exist. "
+                        "Ensure test_data_ref is configured so the init container "
+                        "populates the directory before the adapter starts."
+                    )
                 os.environ["HF_HOME"] = test_data_dir
                 os.environ["HF_DATASETS_OFFLINE"] = "1"
                 os.environ["TRANSFORMERS_OFFLINE"] = "1"


### PR DESCRIPTION
## What and why

Enables fully offline LMEval evaluations on disconnected clusters by reusing the existing `test_data_ref` mechanism to stage both tokenizers and datasets from S3.

When `"offline": true` is set in benchmark parameters, the adapter sets `HF_HOME=/test_data, HF_DATASETS_OFFLINE=1, and TRANSFORMERS_OFFLINE=1`, preventing any HuggingFace network
  access.

Previously only tokenizers could be staged offline. Datasets were always downloaded at runtime, which fails on air-gapped clusters.

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

## Breaking changes

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added offline mode for benchmark jobs: validates presence of local test data, forces tooling to operate in local-only/offline mode (disabling remote downloads), and logs that downloads are disabled. This offline behavior is applied early during job startup so subsequent credential and evaluation steps use local resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->