### PR TITLE
fix(adapter): resolve model credentials and propagate HF token to lm-eval

### DIFF
--- a/main.py
+++ b/main.py
@@ -433,7 +433,12 @@ class LMEvalAdapter(FrameworkAdapter):
             logger.error(f"Evaluation failed: {e}", exc_info=True)
 
             error_str = str(e)
-            is_gated = "gated" in error_str.lower()
+            error_lower = error_str.lower()
+            is_gated = (
+                "gated repo" in error_lower
+                or "gated dataset" in error_lower
+                or ("403" in error_lower and "huggingface" in error_lower)
+            )
 
             if is_gated:
                 error_message = (

--- a/main.py
+++ b/main.py
@@ -36,7 +36,7 @@ from evalhub.adapter import (
     MessageInfo,
     OCIArtifactSpec,
 )
-from evalhub.adapter.auth import resolve_model_credentials
+from evalhub.adapter.auth import read_model_auth_key, resolve_model_credentials
 
 from lm_eval import simple_evaluate
 from lm_eval.tasks import TaskManager
@@ -193,6 +193,15 @@ class LMEvalAdapter(FrameworkAdapter):
                 if auth_value.startswith("Bearer "):
                     token = auth_value.replace("Bearer ", "").strip()
                     os.environ["OPENAI_API_KEY"] = token
+
+            # Set HF_TOKEN for gated dataset access (e.g. leaderboard_gpqa).
+            # Priority: HF_TOKEN env var > hf-token in model auth secret.
+            if not os.environ.get("HF_TOKEN"):
+                hf_token = read_model_auth_key("hf-token")
+                if hf_token:
+                    os.environ["HF_TOKEN"] = hf_token
+                    logger.info("HF_TOKEN set from model auth secret (hf-token)")
+
             job_id = config.id
             benchmark_id = config.benchmark_id
             model_name = config.model.name
@@ -423,6 +432,20 @@ class LMEvalAdapter(FrameworkAdapter):
         except Exception as e:
             logger.error(f"Evaluation failed: {e}", exc_info=True)
 
+            error_str = str(e)
+            is_gated = "gated" in error_str.lower()
+
+            if is_gated:
+                error_message = (
+                    f"Gated HuggingFace dataset error: {error_str}. "
+                    "Set HF_TOKEN by adding an 'hf-token' key to your "
+                    "model auth secret (model.auth.secret_ref)."
+                )
+                error_code = "gated_dataset_auth_required"
+            else:
+                error_message = error_str
+                error_code = "evaluation_failed"
+
             # Report failure
             callbacks.report_status(
                 JobStatusUpdate(
@@ -430,11 +453,11 @@ class LMEvalAdapter(FrameworkAdapter):
                     phase=JobPhase.COMPLETED,
                     progress=0.0,
                     message=_status_message(
-                        "Evaluation failed", code="evaluation_failed"
+                        "Evaluation failed", code=error_code
                     ),
                     error=ErrorInfo(
-                        message=str(e),
-                        message_code="evaluation_failed",
+                        message=error_message,
+                        message_code=error_code,
                     ),
                     error_details={"exception_type": type(e).__name__},
                 )

--- a/main.py
+++ b/main.py
@@ -430,7 +430,7 @@ class LMEvalAdapter(FrameworkAdapter):
             return job_results
 
         except Exception as e:
-            logger.error(f"Evaluation failed: {e}", exc_info=True)
+            logger.error("Evaluation failed", exc_info=True)
 
             error_str = str(e)
             error_lower = error_str.lower()
@@ -442,13 +442,13 @@ class LMEvalAdapter(FrameworkAdapter):
 
             if is_gated:
                 error_message = (
-                    f"Gated HuggingFace dataset error: {error_str}. "
+                    "Gated HuggingFace dataset error; authentication required. "
                     "Set HF_TOKEN by adding an 'hf-token' key to your "
                     "model auth secret (model.auth.secret_ref)."
                 )
                 error_code = "gated_dataset_auth_required"
             else:
-                error_message = error_str
+                error_message = f"Evaluation failed: {type(e).__name__}"
                 error_code = "evaluation_failed"
 
             # Report failure


### PR DESCRIPTION
## Description

Benchmarks that use gated HuggingFace datasets (e.g. leaderboard_gpqa / Idavidrein/gpqa) fail with 401 because the adapter had no way to pass an HF token to the datasets library. The model auth secret is already volume-mounted at /var/run/secrets/model/, so the adapter now reads the hf-token key from it and sets HF_TOKEN in the environment before calling simple_evaluate. An existing HF_TOKEN env var takes priority.                                                                                                                                                                                                      
                                                                                                                                                                                                                 
Also improves error reporting for gated dataset failures: the error message now tells the user to add an hf-token key to their model auth secret, and the error code is gated_dataset_auth_required instead of the generic evaluation_failed.                                                                                         
                                                                                                                                                                                                                    
## How Has This Been Tested?

Manual test with the leaderboard collection.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic use of stored model auth tokens to enable access to gated HuggingFace datasets during evaluation (with logging when applied).

* **Bug Fixes**
  * Improved failure detection to distinguish gated-auth failures from other errors and report distinct, actionable status and messages guiding credential setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->