### PR TITLE
cherrry-pick: concurrent support for EvalHub adapter

### DIFF
--- a/main.py
+++ b/main.py
@@ -80,8 +80,20 @@ def build_lmeval_config(job_spec: JobSpec) -> tuple[str, dict, str | None]:
     benchmark_params = job_spec.parameters
 
     # Adapter-specific settings from parameters
+    _MAX_CONCURRENT = 128
     batch_size = int(benchmark_params.get("batch_size", 1))
-    num_concurrent = int(benchmark_params.get("num_concurrent", 1))
+    _raw_concurrent = int(benchmark_params.get("num_concurrent", 1))
+    if _raw_concurrent <= 0:
+        raise ValueError(
+            f"num_concurrent must be a positive integer, got {_raw_concurrent}"
+        )
+    num_concurrent = min(_raw_concurrent, _MAX_CONCURRENT)
+    if num_concurrent < _raw_concurrent:
+        logger.warning(
+            "num_concurrent clamped from %d to maximum %d",
+            _raw_concurrent,
+            _MAX_CONCURRENT,
+        )
     timeout_seconds = int(benchmark_params.get("timeout_seconds", 300))
 
     # Optional generation parameters for generate_until tasks.

--- a/main.py
+++ b/main.py
@@ -81,6 +81,7 @@ def build_lmeval_config(job_spec: JobSpec) -> tuple[str, dict, str | None]:
 
     # Adapter-specific settings from parameters
     batch_size = int(benchmark_params.get("batch_size", 1))
+    num_concurrent = int(benchmark_params.get("num_concurrent", 1))
     timeout_seconds = int(benchmark_params.get("timeout_seconds", 300))
 
     # Optional generation parameters for generate_until tasks.
@@ -114,6 +115,14 @@ def build_lmeval_config(job_spec: JobSpec) -> tuple[str, dict, str | None]:
             f"(e.g., 'google/flan-t5-small' or 'meta-llama/Llama-3.1-8B-Instruct')"
         )
 
+    if num_concurrent <= 1:
+        logger.info(
+            "Concurrent requests are disabled (num_concurrent=1). "
+            "Add num_concurrent to benchmark parameters to enable."
+        )
+    else:
+        logger.info("Concurrent requests enabled: num_concurrent=%d", num_concurrent)
+
     # Use local-completions backend for OpenAI-compatible endpoints.
     # tokenized_requests=False ensures we send string prompts, not token IDs.
     return (
@@ -124,6 +133,7 @@ def build_lmeval_config(job_spec: JobSpec) -> tuple[str, dict, str | None]:
             "tokenizer_backend": "huggingface",
             "tokenizer": tokenizer,
             "tokenized_requests": False,
+            "num_concurrent": num_concurrent,
             "batch_size": batch_size,
             "timeout": timeout_seconds,
         },


### PR DESCRIPTION
## Description

Add support for `num_concurrent` on EvalHub's adapter.

Cherry pick of:

* 68d43a1f27dc49d314ee12527b38240a9c63d721
* b8d7e1e72206d5d3e760e2218308d588692b40d3