### PR TITLE
fix: use np.NaN in bbq (#2937)

### DIFF
--- a/lm_eval/tasks/bbq/utils.py
+++ b/lm_eval/tasks/bbq/utils.py
@@ -4,6 +4,9 @@ import datasets
 import numpy as np
 
 
+if np.__version__ >= "2.0":
+    np.NaN = np.nan
+
 # Possible unknown responses, copied from the HELM implementation
 UNKNOWN_RESPONSES = [
     "Unknown",


### PR DESCRIPTION
## Description

Fix https://github.com/EleutherAI/lm-evaluation-harness/issues/2935 (bbq np.NaN error)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added NumPy 2.x compatibility to maintain consistent evaluation metrics and bias calculation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->