### PR TITLE
fix: resolve issues in airgapped env

### DIFF
--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -55,9 +55,11 @@ eval_logger = logging.getLogger(__name__)
 
 
 def _offline_datasetdict_bundle_dir(
-    hf_home: str, dataset_path: str, dataset_name: Optional[str]
+    hf_home: Optional[str], dataset_path: str, dataset_name: Optional[str]
 ) -> Optional[Path]:
     """Resolve ``HF_HOME/<slug>/`` when it contains ``dataset_dict.json`` (DatasetDict export layout).
+
+    ``hf_home`` must come from the environment (e.g. ``HF_HOME``); if unset, returns ``None``.
 
     Slug is ``dataset_path`` with ``/`` replaced by ``--``. If ``dataset_name`` is set (subset),
     append ``--`` + ``dataset_name``. When there is no subset (e.g. ``hellaswag``, ``blimp``),
@@ -98,7 +100,7 @@ def _load_datasetdict_from_offline_bundle(bundle: Path) -> Any:
                 "with this `datasets` build (usually the bundle was saved with another "
                 "`datasets`/PyArrow version). Re-run DatasetDict.save_to_disk using the same "
                 f"`datasets` and `pyarrow` versions as the eval image (here: datasets {datasets.__version__}), "
-                "then re-upload to MinIO."
+                "then re-upload."
             ) from exc
         raise
 
@@ -324,7 +326,7 @@ class Task(abc.ABC):
 
         if offline:
             bundle = _offline_datasetdict_bundle_dir(
-                os.environ.get("HF_HOME", "/test_data"),
+                os.environ.get("HF_HOME"),
                 self.DATASET_PATH,
                 self.DATASET_NAME,
             )
@@ -341,7 +343,7 @@ class Task(abc.ABC):
             "cache_dir": cache_dir,
             "download_mode": download_mode,
         }
-        # Offline: standard datasets.load_dataset — rely on HF_HOME (hub + datasets caches synced from MinIO).
+        # Offline: standard datasets.load_dataset — rely on HF_HOME (hub + datasets caches from offline mirror).
         if offline:
             kwargs["download_config"] = DownloadConfig(local_files_only=True)
 
@@ -1016,7 +1018,7 @@ class ConfigurableTask(Task):
         )
         if offline:
             bundle = _offline_datasetdict_bundle_dir(
-                os.environ.get("HF_HOME", "/test_data"),
+                os.environ.get("HF_HOME"),
                 self.DATASET_PATH,
                 self.DATASET_NAME,
             )

--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -1,10 +1,12 @@
 import abc
 import ast
 import logging
+import os
 import random
 import re
 from collections.abc import Callable
-from copy import deepcopy
+from pathlib import Path
+from copy import copy, deepcopy
 from dataclasses import asdict, dataclass
 from inspect import getsource
 from typing import (
@@ -21,6 +23,7 @@ from typing import (
 )
 
 import datasets
+from datasets import DownloadConfig
 import numpy as np
 from tqdm import tqdm
 
@@ -49,6 +52,55 @@ ALL_OUTPUT_TYPES = [
 ]
 
 eval_logger = logging.getLogger(__name__)
+
+
+def _offline_datasetdict_bundle_dir(
+    hf_home: str, dataset_path: str, dataset_name: Optional[str]
+) -> Optional[Path]:
+    """Resolve ``HF_HOME/<slug>/`` when it contains ``dataset_dict.json`` (DatasetDict export layout).
+
+    Slug is ``dataset_path`` with ``/`` replaced by ``--``. If ``dataset_name`` is set (subset),
+    append ``--`` + ``dataset_name``. When there is no subset (e.g. ``hellaswag``, ``blimp``),
+    only the path segment is used.
+    Example: ``allenai/ai2_arc`` + ``ARC-Easy`` -> ``allenai--ai2_arc--ARC-Easy`` under HF_HOME.
+    Example: ``hellaswag`` + ``None`` -> ``hellaswag`` under HF_HOME.
+    """
+    if not hf_home or not dataset_path:
+        return None
+    if dataset_name and ("/" in dataset_name or "\\" in dataset_name):
+        return None
+    root = Path(hf_home).resolve()
+    slug = dataset_path.replace("/", "--")
+    if dataset_name:
+        slug += "--" + dataset_name
+    if not slug or ".." in slug:
+        return None
+    bundle = (root / slug).resolve()
+    try:
+        bundle.relative_to(root)
+    except ValueError:
+        return None
+    if not (bundle / "dataset_dict.json").is_file():
+        return None
+    return bundle
+
+
+def _load_datasetdict_from_offline_bundle(bundle: Path) -> Any:
+    """Load a DatasetDict export from disk; clarify failures caused by datasets/PyArrow version skew."""
+    try:
+        return datasets.load_from_disk(str(bundle))
+    except TypeError as exc:
+        # e.g. Features.from_dict -> "must be called with a dataclass type or instance" when
+        # dataset_info.json was produced by a different `datasets` major than this runtime.
+        if "dataclass" in str(exc).lower():
+            raise RuntimeError(
+                f"Offline load_from_disk failed for {bundle}: on-disk metadata is incompatible "
+                "with this `datasets` build (usually the bundle was saved with another "
+                "`datasets`/PyArrow version). Re-run DatasetDict.save_to_disk using the same "
+                f"`datasets` and `pyarrow` versions as the eval image (here: datasets {datasets.__version__}), "
+                "then re-upload to MinIO."
+            ) from exc
+        raise
 
 
 @dataclass
@@ -265,12 +317,38 @@ class Task(abc.ABC):
             - `datasets.DownloadMode.FORCE_REDOWNLOAD`
                 Fresh download and fresh dataset.
         """
+        offline = (
+            os.environ.get("HF_DATASETS_OFFLINE") == "1"
+            or os.environ.get("HF_HUB_OFFLINE") == "1"
+        )
+
+        if offline:
+            bundle = _offline_datasetdict_bundle_dir(
+                os.environ.get("HF_HOME", "/test_data"),
+                self.DATASET_PATH,
+                self.DATASET_NAME,
+            )
+            if bundle is not None:
+                eval_logger.info(
+                    "Offline: loading DatasetDict bundle at %s",
+                    bundle,
+                )
+                self.dataset = _load_datasetdict_from_offline_bundle(bundle)
+                return
+
+        kwargs: Dict[str, Any] = {
+            "data_dir": data_dir,
+            "cache_dir": cache_dir,
+            "download_mode": download_mode,
+        }
+        # Offline: standard datasets.load_dataset — rely on HF_HOME (hub + datasets caches synced from MinIO).
+        if offline:
+            kwargs["download_config"] = DownloadConfig(local_files_only=True)
+
         self.dataset = datasets.load_dataset(
             path=self.DATASET_PATH,
             name=self.DATASET_NAME,
-            data_dir=data_dir,
-            cache_dir=cache_dir,
-            download_mode=download_mode,
+            **kwargs,
         )
 
     @property
@@ -931,10 +1009,45 @@ class ConfigurableTask(Task):
                     )
 
     def download(self, dataset_kwargs: Optional[Dict[str, Any]] = None) -> None:
+        kwargs = dict(dataset_kwargs if dataset_kwargs is not None else {})
+        offline = (
+            os.environ.get("HF_DATASETS_OFFLINE") == "1"
+            or os.environ.get("HF_HUB_OFFLINE") == "1"
+        )
+        if offline:
+            bundle = _offline_datasetdict_bundle_dir(
+                os.environ.get("HF_HOME", "/test_data"),
+                self.DATASET_PATH,
+                self.DATASET_NAME,
+            )
+            if bundle is not None:
+                eval_logger.info(
+                    "Offline: loading DatasetDict bundle at %s",
+                    bundle,
+                )
+                self.dataset = _load_datasetdict_from_offline_bundle(bundle)
+                return
+        # Offline: standard datasets.load_dataset — rely on HF_HOME caches; merge local_files_only into download_config.
+        if offline:
+            existing = kwargs.get("download_config")
+            if existing is None:
+                dc = DownloadConfig(local_files_only=True)
+            else:
+                try:
+                    dc = copy(existing)
+                    dc.local_files_only = True
+                except (TypeError, AttributeError) as exc:
+                    eval_logger.warning(
+                        "Offline: failed to copy existing download_config (%s); falling back to local_files_only DownloadConfig",
+                        exc,
+                    )
+                    dc = DownloadConfig(local_files_only=True)
+            kwargs["download_config"] = dc
+
         self.dataset = datasets.load_dataset(
             path=self.DATASET_PATH,
             name=self.DATASET_NAME,
-            **dataset_kwargs if dataset_kwargs is not None else {},
+            **kwargs,
         )
 
     def has_training_docs(self) -> bool:

--- a/main.py
+++ b/main.py
@@ -11,6 +11,10 @@ Optional environment variables:
 - EVALHUB_JOB_SPEC_PATH: path to the job spec JSON (defaults to `meta/job.json`)
 - REGISTRY_USERNAME: Registry username (optional)
 - REGISTRY_PASSWORD: Registry password/token (optional)
+
+Disconnected clusters: set `"offline": true` under `parameters` in the job spec so HF libraries use
+local caches under HF_HOME (default `/test_data`). The offline flag is read once from JSON before
+importing lm_eval so Hugging Face env vars apply in time.
 """
 
 import json
@@ -22,6 +26,48 @@ import time
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+
+_TEST_DATA_DIR = "/test_data"
+
+
+def _job_spec_file_requests_offline() -> bool:
+    """Read parameters.offline from job JSON only (no JobSpec yet). Used to set HF env before lm_eval import."""
+    path = os.environ.get("EVALHUB_JOB_SPEC_PATH", "/meta/job.json")
+    try:
+        with open(path, encoding="utf-8") as f:
+            spec = json.load(f)
+        return bool(spec.get("parameters", {}).get("offline"))
+    except FileNotFoundError:
+        return False
+    except (OSError, json.JSONDecodeError, TypeError) as exc:
+        print(
+            f"WARNING: failed to read job spec for offline mode from {path!r}: {exc}",
+            file=sys.stderr,
+        )
+        return False
+
+
+def configure_hf_offline_environment(hf_home: str) -> None:
+    """Use local Hugging Face caches only (disconnected / no huggingface.co).
+
+    Pin Hub/datasets cache dirs under hf_home so lookups match /test_data layout after init sync.
+    HF_HOME, HF_HUB_CACHE and HF_DATASETS_CACHE are set consistently so they stay aligned.
+    """
+    root = Path(hf_home)
+    os.environ["HF_HOME"] = str(root)
+    os.environ["HF_HUB_CACHE"] = str(root / "hub")
+    os.environ["HF_DATASETS_CACHE"] = str(root / "datasets")
+    os.environ["HF_HUB_OFFLINE"] = "1"
+    os.environ["HF_DATASETS_OFFLINE"] = "1"
+    os.environ["HF_EVALUATE_OFFLINE"] = "1"
+    os.environ["TRANSFORMERS_OFFLINE"] = "1"
+
+
+def _seed_hf_offline_before_lm_eval_import() -> None:
+    if not _job_spec_file_requests_offline():
+        return
+    configure_hf_offline_environment(os.environ.get("HF_HOME", _TEST_DATA_DIR))
+
 
 from evalhub.adapter import (
     DefaultCallbacks,
@@ -39,8 +85,13 @@ from evalhub.adapter import (
 )
 from evalhub.adapter.auth import read_model_auth_key, resolve_model_credentials
 
-from lm_eval import simple_evaluate
-from lm_eval.tasks import TaskManager
+
+_seed_hf_offline_before_lm_eval_import()
+
+# NOTE: keep these imports after _seed_hf_offline_before_lm_eval_import() so HF offline env vars
+# are set before lm_eval (and Hugging Face libraries) are imported.
+from lm_eval import simple_evaluate  # noqa: E402
+from lm_eval.tasks import TaskManager  # noqa: E402
 
 
 # Configure logging
@@ -238,18 +289,15 @@ class LMEvalAdapter(FrameworkAdapter):
             # use only local data from /test_data (populated by the init container
             # from S3 via test_data_ref).  This covers both datasets and tokenizers.
             if config.parameters.get("offline"):
-                test_data_dir = "/test_data"
+                test_data_dir = _TEST_DATA_DIR
                 if not os.path.isdir(test_data_dir):
                     raise RuntimeError(
                         f"Offline mode requested but {test_data_dir} does not exist. "
                         "Ensure test_data_ref is configured so the init container "
                         "populates the directory before the adapter starts."
                     )
-                os.environ["HF_HOME"] = test_data_dir
-                os.environ["HF_HUB_OFFLINE"] = "1"
-                os.environ["HF_DATASETS_OFFLINE"] = "1"
-                os.environ["HF_EVALUATE_OFFLINE"] = "1"
-                os.environ["TRANSFORMERS_OFFLINE"] = "1"
+                # Idempotent re-apply: import-time seed may have set HF_* from the same job JSON.
+                configure_hf_offline_environment(test_data_dir)
                 logger.info(
                     "Offline mode enabled: HF_HOME=%s, downloads disabled",
                     test_data_dir,

--- a/main.py
+++ b/main.py
@@ -36,7 +36,12 @@ def _job_spec_file_requests_offline() -> bool:
     try:
         with open(path, encoding="utf-8") as f:
             spec = json.load(f)
-        return bool(spec.get("parameters", {}).get("offline"))
+        if not isinstance(spec, dict):
+            return False
+        parameters = spec.get("parameters")
+        if not isinstance(parameters, dict):
+            parameters = {}
+        return bool(parameters.get("offline"))
     except FileNotFoundError:
         return False
     except (OSError, json.JSONDecodeError, TypeError) as exc:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fixes evaluation failures in air-gapped/disconnected clusters where
`load_dataset()` attempts to contact the HF Hub even when
offline env vars (`HF_DATASETS_OFFLINE`, `HF_HUB_OFFLINE`) are set.

Two root causes were identified and fixed:

**1. Wrong import timing (main.py)**
HF libraries read env vars at import time. The offline flags were
previously set after `lm_eval` was imported, making them ineffective.
Fixed by reading `parameters.offline` from the job JSON early, setting
all HF env vars, and only then importing lm_eval.

**2. Wrong loading method (task.py)**
`load_dataset()` with `local_files_only=True` still triggers HF
metadata resolution — a known HF library issue. Fixed by switching to
`load_from_disk()`, which reads pre-saved Arrow bundles directly with
zero network calls.

Datasets must be pre-downloaded using `DatasetDict.save_to_disk()` and
uploaded to MinIO. 

Both `Task.download()` and `ConfigurableTask.download()` are updated.
If no pre-saved bundle is found, the code falls back to the existing
`local_files_only` behaviour.


References:
1) HF datasets offline metadata issue: https://github.com/huggingface/datasets/issues/6837
2) Offline bundle lookup: _offline_datasetdict_bundle_dir in lm_eval/api/task.py (uses load_from_disk() first, then falls back to load_dataset(..., local_files_only=True))
3) Repro/scripts used: https://github.com/scheruku-rh/disconnected-cluster-scripts

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by simulating air-gapped env in a dev cluster with arc_easy and blimp benchmarks.

arc_easy:
```
 oc logs 722cde53-8204-46b3-a805-3e-23982d5e-1d6f-435d-889d-620b7509wqrs   -f -n dataplane
Defaulted container "adapter" out of: adapter, init (init), sidecar (init)
2026-05-06 15:11:51,451 - evalhub.adapter.models.adapter - INFO - Loading job spec from /meta/job.json
2026-05-06 15:11:51,452 - __main__ - INFO - LMEval adapter initialized
2026-05-06 15:11:51,453 - __main__ - INFO - ================================================================================
2026-05-06 15:11:51,453 - __main__ - INFO - LMEval EvalHub Adapter
2026-05-06 15:11:51,453 - __main__ - INFO - ================================================================================
2026-05-06 15:11:51,453 - __main__ - INFO - Loaded job spec from: /meta/job.json
2026-05-06 15:11:51,453 - __main__ - INFO - Job spec configuration:
2026-05-06 15:11:51,453 - __main__ - INFO -   Job ID: 722cde53-8204-46b3-a805-3e84c72f77b4
2026-05-06 15:11:51,453 - __main__ - INFO -   Benchmark: arc_easy
2026-05-06 15:11:51,453 - __main__ - INFO -   Model: meta-llama/Llama-3.2-1B-Instruct
2026-05-06 15:11:51,453 - __main__ - INFO -   Examples: 100
2026-05-06 15:11:51,453 - __main__ - INFO -   Few-shot: None
2026-05-06 15:11:51,453 - __main__ - INFO - ================================================================================
2026-05-06 15:11:51,453 - __main__ - INFO - Callback URL: http://localhost:8080
2026-05-06 15:11:51,453 - __main__ - INFO - Provider ID: lm_evaluation_harness
2026-05-06 15:11:51,453 - __main__ - INFO - OCI registry auth config present: False
2026-05-06 15:11:51,453 - __main__ - INFO - OCI insecure: False
2026-05-06 15:11:51,453 - __main__ - INFO - EvalHub insecure: False
2026-05-06 15:11:51,453 - __main__ - INFO - ================================================================================
2026-05-06 15:11:51,536 - __main__ - INFO - Offline mode enabled: HF_HOME=/test_data, downloads disabled
2026-05-06 15:11:51,536 - __main__ - INFO - Concurrent requests are disabled (num_concurrent=1). Add num_concurrent to benchmark parameters to enable.
2026-05-06 15:11:51,567 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/722cde53-8204-46b3-a805-3e84c72f77b4/events "HTTP/1.1 204 No Content"
2026-05-06 15:11:51,567 - __main__ - INFO - Job ID: 722cde53-8204-46b3-a805-3e84c72f77b4
2026-05-06 15:11:51,568 - __main__ - INFO - Model: meta-llama/Llama-3.2-1B-Instruct
2026-05-06 15:11:51,568 - __main__ - INFO - Benchmark: arc_easy
2026-05-06 15:11:51,568 - __main__ - INFO - Examples limit: 100
2026-05-06 15:11:51,568 - __main__ - INFO - Few-shot: 0
2026-05-06 15:11:51,568 - __main__ - INFO - Device: cpu (forced)
2026-05-06 15:11:51,568 - __main__ - INFO - Model backend: local-completions
2026-05-06 15:11:51,573 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/722cde53-8204-46b3-a805-3e84c72f77b4/events "HTTP/1.1 204 No Content"
2026-05-06 15:11:54,819 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/722cde53-8204-46b3-a805-3e84c72f77b4/events "HTTP/1.1 204 No Content"
2026-05-06 15:11:54,821 - lm_eval.evaluator - INFO - Setting random seed to 42 | Setting numpy seed to 42 | Setting torch manual seed to 42 | Setting fewshot manual seed to 1234
2026-05-06 15:11:54,821 - lm_eval.evaluator - INFO - Initializing local-completions model, with arguments: {'model': 'meta-llama/Llama-3.2-1B-Instruct', 'base_url': 'https://vllm-llama-prabhu.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1/completions', 'tokenizer_backend': 'huggingface', 'tokenizer': '/test_data/tokenizer', 'tokenized_requests': False, 'num_concurrent': 1, 'batch_size': 1, 'timeout': 300}
2026-05-06 15:11:54,821 - lm_eval.models.api_models - INFO - Using max length 2048 - 1
2026-05-06 15:11:54,821 - lm_eval.models.api_models - INFO - Concurrent requests are disabled. To enable concurrent requests, set `num_concurrent` > 1.
2026-05-06 15:11:54,821 - lm_eval.models.api_models - INFO - Using tokenizer huggingface
2026-05-06 15:11:55,341 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/allenai--ai2_arc--ARC-Easy
2026-05-06 15:11:55,520 - lm_eval.evaluator - WARNING - Overwriting default num_fewshot of arc_easy from None to 0
2026-05-06 15:11:55,520 - lm_eval.api.task - INFO - Building contexts for arc_easy on rank 0...
100%|██████████| 100/100 [00:00<00:00, 894.50it/s]
2026-05-06 15:11:55,636 - lm_eval.evaluator - INFO - Running loglikelihood requests
Requesting API: 100%|██████████| 399/399 [00:14<00:00, 26.84it/s]
fatal: not a git repository (or any of the parent directories): .git
2026-05-06 15:12:11,823 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/722cde53-8204-46b3-a805-3e84c72f77b4/events "HTTP/1.1 204 No Content"
2026-05-06 15:12:11,829 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/722cde53-8204-46b3-a805-3e84c72f77b4/events "HTTP/1.1 204 No Content"
2026-05-06 15:12:11,829 - __main__ - INFO - No OCI exports configured; skipping artifact persistence
2026-05-06 15:12:11,831 - __main__ - INFO - ================================================================================
2026-05-06 15:12:11,831 - __main__ - INFO - Evaluation completed successfully
2026-05-06 15:12:11,831 - __main__ - INFO - Overall score: 0.64
2026-05-06 15:12:11,831 - __main__ - INFO - Examples evaluated: 100
2026-05-06 15:12:11,831 - __main__ - INFO - Duration: 20.29s
2026-05-06 15:12:11,831 - __main__ - INFO - ================================================================================
2026-05-06 15:12:11,838 - evalhub.adapter.callbacks - INFO - Environment Card auto-captured (completeness: 15%)
2026-05-06 15:12:11,844 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/722cde53-8204-46b3-a805-3e84c72f77b4/events "HTTP/1.1 204 No Content"
2026-05-06 15:12:11,845 - evalhub.adapter.callbacks - INFO - Results reported to evalhub | Metrics: 4 | Score: 0.64
2026-05-06 15:12:11,845 - evalhub.adapter.callbacks - INFO - Job 722cde53-8204-46b3-a805-3e84c72f77b4 completed | Benchmark: arc_easy | Model: meta-llama/Llama-3.2-1B-Instruct | Score: 0.64 | Examples: 100 | Duration: 20.29s
```


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added offline dataset support, enabling evaluation without internet connectivity
  * Enhanced fewshot prompt generation with improved chat template and multiturn conversation handling
  * Improved offline Hugging Face integration for streamlined offline mode configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->