### PR TITLE
feat(adapter): HF offline auto-detect via /test_data + tokenizer (no offline flag)

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,13 +8,18 @@ Required environment variables:
 - REGISTRY_URL: OCI registry URL
 
 Optional environment variables:
-- EVALHUB_JOB_SPEC_PATH: path to the job spec JSON (defaults to `meta/job.json`)
+- EVALHUB_JOB_SPEC_PATH: path to the job spec JSON (defaults to ``/meta/job.json``); must resolve under ``/meta``
 - REGISTRY_USERNAME: Registry username (optional)
 - REGISTRY_PASSWORD: Registry password/token (optional)
 
-Disconnected clusters: set `"offline": true` under `parameters` in the job spec so HF libraries use
-local caches under HF_HOME (default `/test_data`). The offline flag is read once from JSON before
-importing lm_eval so Hugging Face env vars apply in time.
+Offline / air-gapped clusters: The job file is read before ``lm_eval`` loads (see
+``_seed_hf_offline_before_lm_eval_import``). The adapter only checks top-level
+``parameters.tokenizer``—the same tokenizer path used everywhere else, not anything under nested
+``parameters.parameters``. If that path exists on disk, sits under ``/test_data`` but is not the
+``/test_data`` mount path by itself, and another folder next to it under ``/test_data`` contains
+``dataset_dict.json`` (offline dataset files, e.g. next to ``tokenizer/``), the adapter turns on
+Hugging Face offline mode: it sets ``HF_HOME`` and related env vars so those libraries use local
+files and do not call the Hub. You do not need ``parameters.offline``.
 """
 
 import json
@@ -28,28 +33,150 @@ from pathlib import Path
 from typing import Any
 
 _TEST_DATA_DIR = "/test_data"
+# EvalHub mounts the job spec JSON under this directory only; reject other paths (CWE-22).
+_JOB_SPEC_ALLOWED_ROOT = Path("/meta")
 
 
-def _job_spec_file_requests_offline() -> bool:
-    """Read parameters.offline from job JSON only (no JobSpec yet). Used to set HF env before lm_eval import."""
-    path = os.environ.get("EVALHUB_JOB_SPEC_PATH", "/meta/job.json")
+def _resolve_job_spec_path_for_read(path: str) -> Path | None:
+    """Return a resolved path to open, or None if ``path`` is invalid or escapes ``/meta``."""
+    if not isinstance(path, str) or not path.strip():
+        print("WARNING: job spec path is empty; refusing to open", file=sys.stderr)
+        return None
     try:
-        with open(path, encoding="utf-8") as f:
-            spec = json.load(f)
-        if not isinstance(spec, dict):
-            return False
-        parameters = spec.get("parameters")
-        if not isinstance(parameters, dict):
-            parameters = {}
-        return bool(parameters.get("offline"))
-    except FileNotFoundError:
-        return False
-    except (OSError, json.JSONDecodeError, TypeError) as exc:
+        resolved = Path(path.strip()).resolve()
+    except (OSError, ValueError) as exc:
+        print(f"WARNING: invalid job spec path {path!r}: {exc}", file=sys.stderr)
+        return None
+    try:
+        allowed = _JOB_SPEC_ALLOWED_ROOT.resolve()
+    except OSError:
+        allowed = _JOB_SPEC_ALLOWED_ROOT
+    if not resolved.is_relative_to(allowed):
         print(
-            f"WARNING: failed to read job spec for offline mode from {path!r}: {exc}",
+            f"WARNING: job spec path {path!r} resolves to {resolved} "
+            f"which is not under {allowed}; refusing to open",
             file=sys.stderr,
         )
+        return None
+    return resolved
+
+
+def _read_job_spec_parameters_from_path(path: str) -> dict[str, Any]:
+    """Load top-level ``parameters`` object from the job spec JSON file.
+
+    Only files whose resolved path stays under ``/meta`` are opened (see ``EVALHUB_JOB_SPEC_PATH``).
+    """
+    resolved = _resolve_job_spec_path_for_read(path)
+    if resolved is None:
+        return {}
+    try:
+        with open(resolved, encoding="utf-8") as f:
+            spec = json.load(f)
+    except FileNotFoundError:
+        return {}
+    except PermissionError as exc:
+        print(
+            f"WARNING: permission denied reading job spec {resolved!r}: {exc}",
+            file=sys.stderr,
+        )
+        return {}
+    except OSError as exc:
+        print(f"WARNING: I/O error reading job spec {resolved!r}: {exc}", file=sys.stderr)
+        return {}
+    except json.JSONDecodeError as exc:
+        print(f"WARNING: invalid JSON in job spec {resolved!r}: {exc}", file=sys.stderr)
+        return {}
+    except TypeError as exc:
+        print(
+            f"WARNING: unexpected type while parsing job spec {resolved!r}: {exc}",
+            file=sys.stderr,
+        )
+        return {}
+    if not isinstance(spec, dict):
+        return {}
+    parameters = spec.get("parameters")
+    if not isinstance(parameters, dict):
+        return {}
+    return parameters
+
+
+def _extract_tokenizer_parameter(parameters: dict[str, Any]) -> str | None:
+    """Tokenizer path or id from benchmark ``parameters.tokenizer`` (must match ``build_lmeval_config``).
+
+    Only the top-level key is used—the same source as ``model_args["tokenizer"]``—so HF offline
+    auto-detection never diverges from the tokenizer the adapter actually loads.
+    """
+    raw = parameters.get("tokenizer")
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip()
+    return None
+
+
+def _dataset_material_present_under_test_data(
+    root_resolved: Path, tokenizer_resolved: Path
+) -> bool:
+    """True when a DatasetDict bundle (``dataset_dict.json``) exists beside the tokenizer path.
+
+    Both paths must already be ``Path.resolve()`` results. Matches EvalHub ``/test_data`` sync:
+    e.g. ``tokenizer/`` and ``allenai--ai2_arc--ARC-Easy/`` as direct children of the mount.
+    """
+    try:
+        for child in root_resolved.iterdir():
+            if not child.is_dir():
+                continue
+            try:
+                cres = child.resolve()
+            except OSError:
+                continue
+            if cres == tokenizer_resolved:
+                continue
+            if tokenizer_resolved.is_relative_to(cres):
+                continue
+            if (child / "dataset_dict.json").is_file():
+                return True
+    except OSError:
         return False
+
+    return False
+
+
+def _infer_auto_offline_from_local_test_data(
+    parameters: dict[str, Any],
+    *,
+    test_data_root: str | Path = _TEST_DATA_DIR,
+) -> bool:
+    """True when ``parameters.tokenizer`` points into ``test_data_root`` and datasets are co-located.
+
+    Tokenizer: absolute path under ``test_data_root``, not the mount root alone, path exists.
+    Datasets: see ``_dataset_material_present_under_test_data`` (same ``/test_data`` directory).
+    """
+    tokenizer_str = _extract_tokenizer_parameter(parameters)
+    if not tokenizer_str or not tokenizer_str.startswith("/"):
+        return False
+
+    root = Path(test_data_root)
+    try:
+        root_res = root.resolve()
+    except OSError:
+        return False
+    if not root_res.is_dir():
+        return False
+
+    tokenizer_path = Path(tokenizer_str)
+    try:
+        tok_res = tokenizer_path.resolve()
+    except OSError:
+        return False
+
+    if tok_res == root_res or not tok_res.is_relative_to(root_res):
+        return False
+    try:
+        if not tok_res.exists():
+            return False
+    except OSError:
+        return False
+
+    return _dataset_material_present_under_test_data(root_res, tok_res)
 
 
 def configure_hf_offline_environment(hf_home: str) -> None:
@@ -69,9 +196,10 @@ def configure_hf_offline_environment(hf_home: str) -> None:
 
 
 def _seed_hf_offline_before_lm_eval_import() -> None:
-    if not _job_spec_file_requests_offline():
+    path = os.environ.get("EVALHUB_JOB_SPEC_PATH", "/meta/job.json")
+    if not _infer_auto_offline_from_local_test_data(_read_job_spec_parameters_from_path(path)):
         return
-    configure_hf_offline_environment(os.environ.get("HF_HOME", _TEST_DATA_DIR))
+    configure_hf_offline_environment(_TEST_DATA_DIR)
 
 
 from evalhub.adapter import (
@@ -290,21 +418,24 @@ class LMEvalAdapter(FrameworkAdapter):
         start_time = time.time()
 
         try:
-            # When offline mode is enabled, configure HuggingFace libraries to
-            # use only local data from /test_data (populated by the init container
-            # from S3 via test_data_ref).  This covers both datasets and tokenizers.
-            if config.parameters.get("offline"):
+            # Auto-detect disconnected layout (see module docstring); re-apply HF env in case
+            # the import-time seed skipped (e.g. job file unreadable at process start).
+            benchmark_params = (
+                config.parameters if isinstance(config.parameters, dict) else {}
+            )
+            hf_offline = _infer_auto_offline_from_local_test_data(benchmark_params)
+            if hf_offline:
                 test_data_dir = _TEST_DATA_DIR
                 if not os.path.isdir(test_data_dir):
                     raise RuntimeError(
-                        f"Offline mode requested but {test_data_dir} does not exist. "
-                        "Ensure test_data_ref is configured so the init container "
-                        "populates the directory before the adapter starts."
+                        f"Local /test_data layout detected from parameters.tokenizer but "
+                        f"{test_data_dir} does not exist. Ensure test_data_ref is configured so "
+                        "the init container populates the directory before the adapter starts."
                     )
-                # Idempotent re-apply: import-time seed may have set HF_* from the same job JSON.
                 configure_hf_offline_environment(test_data_dir)
                 logger.info(
-                    "Offline mode enabled: HF_HOME=%s, downloads disabled",
+                    "HF offline mode (auto-detected from parameters.tokenizer + /test_data): "
+                    "HF_HOME=%s, downloads disabled",
                     test_data_dir,
                 )
 
@@ -334,7 +465,6 @@ class LMEvalAdapter(FrameworkAdapter):
             num_examples = config.num_examples
 
             # Adapter-specific params from parameters
-            benchmark_params = config.parameters
             num_fewshot = int(benchmark_params.get("num_few_shot", 0))
             random_seed = int(benchmark_params.get("random_seed", 42))
 

--- a/tests/test_adapter_offline_inference.py
+++ b/tests/test_adapter_offline_inference.py
@@ -1,0 +1,92 @@
+"""Tests for HF offline auto-detection from ``parameters.tokenizer`` + ``/test_data`` (no ``offline`` flag)."""
+
+from pathlib import Path
+
+import pytest
+
+from main import _infer_auto_offline_from_local_test_data
+
+
+def _touch(p: Path) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("{}", encoding="utf-8")
+
+
+@pytest.fixture
+def fake_test_data(tmp_path: Path) -> Path:
+    """Typical EvalHub sync: ``tokenizer/`` + slug bundle with ``dataset_dict.json``."""
+    root = tmp_path / "test_data"
+    tok = root / "tokenizer"
+    tok.mkdir(parents=True)
+    _touch(tok / "config.json")
+    bundle = root / "allenai--ai2_arc--ARC-Easy"
+    bundle.mkdir(parents=True)
+    _touch(bundle / "dataset_dict.json")
+    return root
+
+
+def test_infer_true_when_tokenizer_and_slug_bundle(fake_test_data: Path) -> None:
+    tok_path = fake_test_data / "tokenizer"
+    params = {"tokenizer": str(tok_path.resolve())}
+    assert _infer_auto_offline_from_local_test_data(params, test_data_root=fake_test_data)
+
+
+def test_nested_parameters_tokenizer_does_not_trigger_offline(fake_test_data: Path) -> None:
+    """Nested ``parameters.parameters.tokenizer`` is not used by ``build_lmeval_config``; infer must match."""
+    tok_path = fake_test_data / "tokenizer"
+    params = {
+        "tokenizer": "google/flan-t5-small",
+        "parameters": {"tokenizer": str(tok_path.resolve())},
+    }
+    assert not _infer_auto_offline_from_local_test_data(
+        params, test_data_root=fake_test_data
+    )
+
+
+def test_infer_false_when_hf_model_id(fake_test_data: Path) -> None:
+    params = {"tokenizer": "google/flan-t5-small"}
+    assert not _infer_auto_offline_from_local_test_data(
+        params, test_data_root=fake_test_data
+    )
+
+
+def test_infer_false_when_tokenizer_path_missing(fake_test_data: Path) -> None:
+    missing = fake_test_data / "nope"
+    params = {"tokenizer": str(missing.resolve())}
+    assert not _infer_auto_offline_from_local_test_data(
+        params, test_data_root=fake_test_data
+    )
+
+
+def test_infer_false_when_no_dataset_dict_sibling(fake_test_data: Path) -> None:
+    """No ``dataset_dict.json`` under a sibling dir → do not infer offline."""
+    bundle = fake_test_data / "allenai--ai2_arc--ARC-Easy"
+    (bundle / "dataset_dict.json").unlink(missing_ok=True)
+    bundle.rmdir()
+    tok_path = fake_test_data / "tokenizer"
+    params = {"tokenizer": str(tok_path.resolve())}
+    assert not _infer_auto_offline_from_local_test_data(
+        params, test_data_root=fake_test_data
+    )
+
+
+def test_infer_false_when_tokenizer_is_root_only(fake_test_data: Path) -> None:
+    params = {"tokenizer": str(fake_test_data.resolve())}
+    assert not _infer_auto_offline_from_local_test_data(
+        params, test_data_root=fake_test_data
+    )
+
+
+def test_infer_false_when_path_outside_root(tmp_path: Path) -> None:
+    root = tmp_path / "test_data"
+    root.mkdir()
+    bundle = root / "some--dataset"
+    bundle.mkdir(parents=True)
+    _touch(bundle / "dataset_dict.json")
+    outside = tmp_path / "other" / "tok"
+    outside.mkdir(parents=True)
+    _touch(outside / "config.json")
+    params = {"tokenizer": str(outside.resolve())}
+    assert not _infer_auto_offline_from_local_test_data(
+        params, test_data_root=root
+    )

--- a/tests/test_job_spec_parameters_path.py
+++ b/tests/test_job_spec_parameters_path.py
@@ -1,0 +1,46 @@
+"""Tests for job spec path validation in ``_read_job_spec_parameters_from_path``."""
+
+from pathlib import Path
+
+import pytest
+
+import main
+
+
+def test_resolve_rejects_path_outside_meta() -> None:
+    assert main._resolve_job_spec_path_for_read("/tmp/job.json") is None
+
+
+def test_resolve_rejects_dotdot_escape() -> None:
+    assert main._resolve_job_spec_path_for_read("/meta/../etc/passwd") is None
+
+
+def test_resolve_accepts_meta_job_json() -> None:
+    resolved = main._resolve_job_spec_path_for_read("/meta/job.json")
+    assert resolved is not None
+    assert resolved == Path("/meta/job.json").resolve()
+
+
+def test_read_parameters_success(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(main, "_JOB_SPEC_ALLOWED_ROOT", tmp_path)
+    job = tmp_path / "job.json"
+    job.write_text('{"parameters": {"limit": 3}}', encoding="utf-8")
+    assert main._read_job_spec_parameters_from_path(str(job)) == {"limit": 3}
+
+
+def test_read_parameters_missing_file_returns_empty(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(main, "_JOB_SPEC_ALLOWED_ROOT", tmp_path)
+    assert main._read_job_spec_parameters_from_path(str(tmp_path / "nope.json")) == {}
+
+
+def test_read_parameters_invalid_json_returns_empty(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(main, "_JOB_SPEC_ALLOWED_ROOT", tmp_path)
+    job = tmp_path / "job.json"
+    job.write_text("{not-json", encoding="utf-8")
+    assert main._read_job_spec_parameters_from_path(str(job)) == {}
+    err = capsys.readouterr().err
+    assert "invalid JSON" in err


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Support disconnected / air-gapped evaluation runs through local tokenizer + dataset under /test_data, without a separate parameters.offline flag in the job.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have tested this by creating an image with this change and tested on dev cluster.

The key is to upload both tokenizer and datasets in Minio. 
Sample payload:
```
"benchmarks": [
    {
      "id": "arc_easy",
      "provider_id": "lm_evaluation_harness",
      "parameters": {
        "limit": 5,
        "num_examples": 100,
        "tokenizer": "google/flan-t5-small"
      },
      "test_data_ref": {
        "s3": {
          "bucket": "mlpipeline",
          "key": "offline_arc_easy/",
          "secret_ref": "minio-test"
        }
      }
    }
  ]
```

Benchmark testing:
Input response:
```
{
  "resource": {
    "id": "d44de8e8-f7e1-43ce-99f4-cc01d884f793",
    "tenant": "dataplane",
    "created_at": "2026-05-11T08:15:45.180343Z",
    "updated_at": "2026-05-11T08:18:35.020909Z",
    "owner": "system:serviceaccount:dataplane:dataplane-sa"
  },
  "status": {
    "state": "completed",
    "message": {
      "message": "Evaluation job is completed",
      "message_code": "evaluation_job_updated"
    },
    "benchmarks": [
      {
        "provider_id": "lm_evaluation_harness",
        "id": "arc_easy",
        "benchmark_index": 0,
        "status": "completed",
        "completed_at": "2026-05-11T08:18:35.003526+00:00"
      }
    ]
  },
  "results": {
    "test": {
      "score": 0.64,
      "threshold": 0.5,
      "pass": true
    },
    "benchmarks": [
      {
        "id": "arc_easy",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 0,
        "metrics": {
          "acc": 0.64,
          "acc_norm": 0.64,
          "acc_norm_stderr": 0.048241815132442176,
          "acc_stderr": 0.048241815132442176
        },
        "artifacts": {
          "evalhub.env_card": {
            "aggregate_results": {},
            "autograder_bias": {},
            "capture_completeness": 0.15,
            "confidence_intervals": {},
            "cpu_model": "x86_64",
            "custom": {},
            "k8s_pod_labels": {},
            "k8s_resource_limits": {},
            "key_packages": {
              "lm_eval": "0.4.8",
              "torch": "2.6.0",
              "transformers": "4.48.0"
            },
            "os_info": "Linux-5.14.0-570.78.1.el9_6.x86_64-x86_64-with-glibc2.34",
            "per_task_results": {},
            "python_version": "3.11.13",
            "scorer_ids": []
          }
        },
        "test": {
          "primary_score": 0.64,
          "primary_score_metric": "acc_norm",
          "threshold": 0.25,
          "pass": true
        }
      }
    ]
  },
  "name": "model offline test",
  "model": {
    "url": "https://vllm-llama-prabhu.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1",
    "name": "meta-llama/Llama-3.2-1B-Instruct"
  },
  "benchmarks": [
    {
      "id": "arc_easy",
      "provider_id": "lm_evaluation_harness",
      "parameters": {
        "limit": 5,
        "num_examples": 100,
        "tokenizer": "/test_data/tokenizer"
      },
      "test_data_ref": {
        "s3": {
          "bucket": "mlpipeline",
          "key": "offline_arc_easy/",
          "secret_ref": "minio-test"
        }
      }
    }
  ]
}
```

Pod logs:
```
oc logs d44de8e8-f7e1-43ce-99f4-cc-1a8e5b10-bd11-433b-ba0a-4c39264n9k6b  -f  -n dataplane

Defaulted container "adapter" out of: adapter, init (init), sidecar (init)
2026-05-11 08:18:14,282 - evalhub.adapter.models.adapter - INFO - Loading job spec from /meta/job.json
2026-05-11 08:18:14,573 - __main__ - INFO - LMEval adapter initialized
2026-05-11 08:18:14,573 - __main__ - INFO - ================================================================================
2026-05-11 08:18:14,573 - __main__ - INFO - LMEval EvalHub Adapter
2026-05-11 08:18:14,573 - __main__ - INFO - ================================================================================
2026-05-11 08:18:14,573 - __main__ - INFO - Loaded job spec from: /meta/job.json
2026-05-11 08:18:14,573 - __main__ - INFO - Job spec configuration:
2026-05-11 08:18:14,573 - __main__ - INFO -   Job ID: d44de8e8-f7e1-43ce-99f4-cc01d884f793
2026-05-11 08:18:14,573 - __main__ - INFO -   Benchmark: arc_easy
2026-05-11 08:18:14,573 - __main__ - INFO -   Model: meta-llama/Llama-3.2-1B-Instruct
2026-05-11 08:18:14,573 - __main__ - INFO -   Examples: 100
2026-05-11 08:18:14,573 - __main__ - INFO -   Few-shot: None
2026-05-11 08:18:14,573 - __main__ - INFO - ================================================================================
2026-05-11 08:18:14,573 - __main__ - INFO - Callback URL: http://localhost:8080
2026-05-11 08:18:14,573 - __main__ - INFO - Provider ID: lm_evaluation_harness
2026-05-11 08:18:14,573 - __main__ - INFO - OCI registry auth config present: False
2026-05-11 08:18:14,573 - __main__ - INFO - OCI insecure: False
2026-05-11 08:18:14,573 - __main__ - INFO - EvalHub insecure: False
2026-05-11 08:18:14,573 - __main__ - INFO - ================================================================================
2026-05-11 08:18:14,607 - __main__ - INFO - HF offline mode (auto-detected from parameters.tokenizer + /test_data): HF_HOME=/test_data, downloads disabled
2026-05-11 08:18:14,607 - __main__ - INFO - Concurrent requests are disabled (num_concurrent=1). Add num_concurrent to benchmark parameters to enable.
2026-05-11 08:18:14,650 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/d44de8e8-f7e1-43ce-99f4-cc01d884f793/events "HTTP/1.1 204 No Content"
2026-05-11 08:18:14,650 - __main__ - INFO - Job ID: d44de8e8-f7e1-43ce-99f4-cc01d884f793
2026-05-11 08:18:14,650 - __main__ - INFO - Model: meta-llama/Llama-3.2-1B-Instruct
2026-05-11 08:18:14,650 - __main__ - INFO - Benchmark: arc_easy
2026-05-11 08:18:14,650 - __main__ - INFO - Examples limit: 100
2026-05-11 08:18:14,650 - __main__ - INFO - Few-shot: 0
2026-05-11 08:18:14,650 - __main__ - INFO - Device: cpu (forced)
2026-05-11 08:18:14,650 - __main__ - INFO - Model backend: local-completions
2026-05-11 08:18:14,656 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/d44de8e8-f7e1-43ce-99f4-cc01d884f793/events "HTTP/1.1 204 No Content"
2026-05-11 08:18:17,800 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/d44de8e8-f7e1-43ce-99f4-cc01d884f793/events "HTTP/1.1 204 No Content"
2026-05-11 08:18:17,802 - lm_eval.evaluator - INFO - Setting random seed to 42 | Setting numpy seed to 42 | Setting torch manual seed to 42 | Setting fewshot manual seed to 1234
2026-05-11 08:18:17,802 - lm_eval.evaluator - INFO - Initializing local-completions model, with arguments: {'model': 'meta-llama/Llama-3.2-1B-Instruct', 'base_url': 'https://vllm-llama-prabhu.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1/completions', 'tokenizer_backend': 'huggingface', 'tokenizer': '/test_data/tokenizer', 'tokenized_requests': False, 'num_concurrent': 1, 'batch_size': 1, 'timeout': 300}
2026-05-11 08:18:17,802 - lm_eval.models.api_models - INFO - Using max length 2048 - 1
2026-05-11 08:18:17,802 - lm_eval.models.api_models - INFO - Concurrent requests are disabled. To enable concurrent requests, set `num_concurrent` > 1.
2026-05-11 08:18:17,802 - lm_eval.models.api_models - INFO - Using tokenizer huggingface
2026-05-11 08:18:18,378 - lm_eval.api.task - INFO - Offline: loading DatasetDict bundle at /test_data/allenai--ai2_arc--ARC-Easy
2026-05-11 08:18:18,505 - lm_eval.evaluator - WARNING - Overwriting default num_fewshot of arc_easy from None to 0
2026-05-11 08:18:18,506 - lm_eval.api.task - INFO - Building contexts for arc_easy on rank 0...
100%|██████████| 100/100 [00:00<00:00, 899.93it/s]
2026-05-11 08:18:18,621 - lm_eval.evaluator - INFO - Running loglikelihood requests
Requesting API: 100%|██████████| 399/399 [00:15<00:00, 26.40it/s]
fatal: not a git repository (or any of the parent directories): .git
2026-05-11 08:18:35,003 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/d44de8e8-f7e1-43ce-99f4-cc01d884f793/events "HTTP/1.1 204 No Content"
2026-05-11 08:18:35,010 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/d44de8e8-f7e1-43ce-99f4-cc01d884f793/events "HTTP/1.1 204 No Content"
2026-05-11 08:18:35,011 - __main__ - INFO - No OCI exports configured; skipping artifact persistence
2026-05-11 08:18:35,012 - __main__ - INFO - ================================================================================
2026-05-11 08:18:35,012 - __main__ - INFO - Evaluation completed successfully
2026-05-11 08:18:35,012 - __main__ - INFO - Overall score: 0.64
2026-05-11 08:18:35,012 - __main__ - INFO - Examples evaluated: 100
2026-05-11 08:18:35,012 - __main__ - INFO - Duration: 20.40s
2026-05-11 08:18:35,012 - __main__ - INFO - ================================================================================
2026-05-11 08:18:35,019 - evalhub.adapter.callbacks - INFO - Environment Card auto-captured (completeness: 15%)
2026-05-11 08:18:35,026 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/d44de8e8-f7e1-43ce-99f4-cc01d884f793/events "HTTP/1.1 204 No Content"
2026-05-11 08:18:35,027 - evalhub.adapter.callbacks - INFO - Results reported to evalhub | Metrics: 4 | Score: 0.64
2026-05-11 08:18:35,027 - evalhub.adapter.callbacks - INFO - Job d44de8e8-f7e1-43ce-99f4-cc01d884f793 completed | Benchmark: arc_easy | Model: meta-llama/Llama-3.2-1B-Instruct | Score: 0.64 | Examples: 100 | Duration: 20.40s

```


Collection testing:
Input response:
```
{
  "resource": {
    "id": "4f9f8dca-716a-4141-8419-0a79ee7e8e4b",
    "tenant": "dataplane",
    "created_at": "2026-05-11T09:33:49.783212Z",
    "updated_at": "2026-05-11T09:37:36.016563Z",
    "owner": "system:serviceaccount:dataplane:dataplane-sa"
  },
  "status": {
    "state": "completed",
    "message": {
      "message": "Evaluation job is completed",
      "message_code": "evaluation_job_updated"
    },
    "benchmarks": [
      {
        "provider_id": "lm_evaluation_harness",
        "id": "truthfulqa_mc1",
        "benchmark_index": 1,
        "status": "completed",
        "completed_at": "2026-05-11T09:37:36.001001+00:00"
      },
      {
        "provider_id": "lm_evaluation_harness",
        "id": "toxigen",
        "benchmark_index": 0,
        "status": "completed",
        "completed_at": "2026-05-11T09:35:48.213751+00:00"
      },
      {
        "provider_id": "lm_evaluation_harness",
        "id": "bigbench_hhh_alignment_multiple_choice",
        "benchmark_index": 2,
        "status": "completed",
        "completed_at": "2026-05-11T09:34:39.787391+00:00"
      }
    ]
  },
  "results": {
    "benchmarks": [
      {
        "id": "bigbench_hhh_alignment_multiple_choice",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 2,
        "metrics": {
          "acc": 0.4253393665158371,
          "acc_stderr": 0.03333206140201842
        },
        "artifacts": {
          "evalhub.env_card": {
            "aggregate_results": {},
            "autograder_bias": {},
            "capture_completeness": 0.15,
            "confidence_intervals": {},
            "cpu_model": "x86_64",
            "custom": {},
            "k8s_pod_labels": {},
            "k8s_resource_limits": {},
            "key_packages": {
              "lm_eval": "0.4.8",
              "torch": "2.6.0",
              "transformers": "4.48.0"
            },
            "os_info": "Linux-5.14.0-570.78.1.el9_6.x86_64-x86_64-with-glibc2.34",
            "per_task_results": {},
            "python_version": "3.11.13",
            "scorer_ids": []
          }
        }
      },
      {
        "id": "toxigen",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 0,
        "metrics": {
          "acc": 0.4074468085106383,
          "acc_norm": 0.42872340425531913,
          "acc_norm_stderr": 0.016150241325972998,
          "acc_stderr": 0.01603490291675187
        },
        "artifacts": {
          "evalhub.env_card": {
            "aggregate_results": {},
            "autograder_bias": {},
            "capture_completeness": 0.15,
            "confidence_intervals": {},
            "cpu_model": "x86_64",
            "custom": {},
            "k8s_pod_labels": {},
            "k8s_resource_limits": {},
            "key_packages": {
              "lm_eval": "0.4.8",
              "torch": "2.6.0",
              "transformers": "4.48.0"
            },
            "os_info": "Linux-5.14.0-570.78.1.el9_6.x86_64-x86_64-with-glibc2.34",
            "per_task_results": {},
            "python_version": "3.11.13",
            "scorer_ids": []
          }
        }
      },
      {
        "id": "truthfulqa_mc1",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 1,
        "metrics": {
          "acc": 0.2729498164014688,
          "acc_stderr": 0.01559475363200653
        },
        "artifacts": {
          "evalhub.env_card": {
            "aggregate_results": {},
            "autograder_bias": {},
            "capture_completeness": 0.15,
            "confidence_intervals": {},
            "cpu_model": "x86_64",
            "custom": {},
            "k8s_pod_labels": {},
            "k8s_resource_limits": {},
            "key_packages": {
              "lm_eval": "0.4.8",
              "torch": "2.6.0",
              "transformers": "4.48.0"
            },
            "os_info": "Linux-5.14.0-570.78.1.el9_6.x86_64-x86_64-with-glibc2.34",
            "per_task_results": {},
            "python_version": "3.11.13",
            "scorer_ids": []
          }
        }
      }
    ]
  },
  "name": "model offline test using collection",
  "model": {
    "url": "https://vllm-llama-prabhu.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1",
    "name": "meta-llama/Llama-3.2-1B-Instruct"
  },
  "collection": {
    "id": "toxicity-and-ethical-principles",
    "benchmarks": [
      {
        "id": "toxigen",
        "provider_id": "lm_evaluation_harness",
        "parameters": {
          "tokenizer": "/test_data/tokenizer"
        },
        "test_data_ref": {
          "s3": {
            "bucket": "mlpipeline",
            "key": "offline_toxigen/",
            "secret_ref": "minio-test"
          }
        }
      },
      {
        "id": "truthfulqa_mc1",
        "provider_id": "lm_evaluation_harness",
        "parameters": {
          "tokenizer": "/test_data/tokenizer"
        },
        "test_data_ref": {
          "s3": {
            "bucket": "mlpipeline",
            "key": "offline_truthful_qa/",
            "secret_ref": "minio-test"
          }
        }
      },
      {
        "id": "bigbench_hhh_alignment_multiple_choice",
        "provider_id": "lm_evaluation_harness",
        "parameters": {
          "tokenizer": "/test_data/tokenizer"
        },
        "test_data_ref": {
          "s3": {
            "bucket": "mlpipeline",
            "key": "offline_bigbench/",
            "secret_ref": "minio-test"
          }
        }
      }
    ]
  }
}
```


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Offline mode detection is now automatic for disconnected and air-gapped environments. The system detects when tokenizers and datasets are available locally and automatically configures necessary environment variables, eliminating the need for manual configuration.

* **Tests**
  * Added test suite validating offline mode auto-detection across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->