### PR TITLE
feat(adapter): map model HTTP errors to EvalHub message codes

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,6 +26,7 @@ import json
 import logging
 import os
 import re
+import requests
 import sys
 import time
 from datetime import UTC, datetime
@@ -296,6 +297,50 @@ def _sanitize_error_message(msg: str) -> str:
     s = re.sub(r"(https?://[^\s?]+)(\?[^\s]*)", r"\1", s)
 
     return s
+
+
+def _evaluation_failure_for_evalhub(exc: BaseException) -> tuple[str, str]:
+    """Return ``(sanitized_message, message_code)`` for a failed lm_eval / adapter run."""
+    error_str = str(exc)
+    error_lower = error_str.lower()
+
+    is_gated = "gated repo" in error_lower or "gated dataset" in error_lower
+
+    if not is_gated:
+        is_gated = (
+            isinstance(exc, requests.HTTPError)
+            and exc.response is not None
+            and exc.response.status_code == 403
+            and "huggingface" in error_lower
+        )
+    if is_gated:
+        return (
+            "Gated HuggingFace dataset error; authentication required. "
+            "Set HF_TOKEN by adding an 'hf-token' key to your "
+            "model auth secret (model.auth.secret_ref).",
+            "gated_dataset_auth_required",
+        )
+
+    if isinstance(exc, requests.HTTPError) and exc.response is not None:
+        sc = exc.response.status_code
+        msg = _sanitize_error_message(f"Model endpoint returned HTTP {sc}: {error_str}")
+        if sc == 401:
+            return msg, "model_authentication_failed"
+        if sc == 403:
+            return msg, "model_access_forbidden"
+        if sc == 404:
+            return msg, "model_endpoint_not_found"
+        if sc == 408:
+            return msg, "model_request_timeout"
+        if sc == 429:
+            return msg, "model_rate_limited"
+        if 500 <= sc < 600:
+            return msg, "model_server_error"
+
+    return (
+        _sanitize_error_message(f"Evaluation failed: {error_str}"),
+        "evaluation_failed",
+    )
 
 
 def build_lmeval_config(job_spec: JobSpec) -> tuple[str, dict, str | None]:
@@ -685,27 +730,7 @@ class LMEvalAdapter(FrameworkAdapter):
         except Exception as e:
             logger.error("Evaluation failed", exc_info=True)
 
-            error_str = str(e)
-            error_lower = error_str.lower()
-            is_gated = (
-                "gated repo" in error_lower
-                or "gated dataset" in error_lower
-                or ("403" in error_lower and "huggingface" in error_lower)
-            )
-
-            if is_gated:
-                error_message = (
-                    "Gated HuggingFace dataset error; authentication required. "
-                    "Set HF_TOKEN by adding an 'hf-token' key to your "
-                    "model auth secret (model.auth.secret_ref)."
-                )
-                error_code = "gated_dataset_auth_required"
-            else:
-                # str(e) carries full text for requests.HTTPError etc.; sanitize before Hub.
-                error_message = _sanitize_error_message(
-                    f"Evaluation failed: {error_str}"
-                )
-                error_code = "evaluation_failed"
+            error_message, error_code = _evaluation_failure_for_evalhub(e)
 
             # Report failure (error_message is sanitized for external callbacks)
             callbacks.report_status(
@@ -713,9 +738,7 @@ class LMEvalAdapter(FrameworkAdapter):
                     status=JobStatus.FAILED,
                     phase=JobPhase.COMPLETED,
                     progress=0.0,
-                    message=_status_message(
-                        "Evaluation failed", code=error_code
-                    ),
+                    message=_status_message("Evaluation failed", code=error_code),
                     error=ErrorInfo(
                         message=error_message,
                         message_code=error_code,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR has changes to return specific `message_code` values at the benchmark level instead of the generic `evaluation_failed`. The fix classifies errors by HTTP status code Ex:
401 -> model_authentication_failed, 
403  ->model_access_forbidden, 
429  -> model_rate_limited, 
5xx  -> model_server_error.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have tested this by creating an image with these changes and deploying it in dev cluster. 

Sample error message responses are provided below:
1.
```
{
  "resource": {
    "id": "80a8989e-7c5a-448c-838e-651e04e1b39f",
    "tenant": "dataplane",
    "created_at": "2026-05-12T13:34:34.187054Z",
    "updated_at": "2026-05-12T13:34:56.940258Z",
    "owner": "system:serviceaccount:dataplane:dataplane-sa"
  },
  "status": {
    "state": "failed",
    "message": {
      "message": "Evaluation job is failed. \nBenchmark arc_easy failed with message: Model endpoint returned HTTP 401: 401 Client Error: Unauthorized for url: http://vllm-route-dataplane.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1/completions\n",
      "message_code": "evaluation_job_updated"
    },
    "benchmarks": [
      {
        "provider_id": "lm_evaluation_harness",
        "id": "arc_easy",
        "benchmark_index": 0,
        "status": "failed",
        "error_message": {
          "message": "Model endpoint returned HTTP 401: 401 Client Error: Unauthorized for url: http://vllm-route-dataplane.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1/completions",
          "message_code": "model_authentication_failed"
        }
      }
    ]
  },
  "results": {
    "benchmarks": [
      {
        "id": "arc_easy",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 0
      }
    ]
  },
  "name": "model api key/cert test",
  "model": {
    "url": "http://vllm-route-dataplane.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1",
    "name": "gpt2"
  },
  "benchmarks": [
    {
      "id": "arc_easy",
      "provider_id": "lm_evaluation_harness",
      "parameters": {
        "limit": 5,
        "num_examples": 1000,
        "tokenizer": "google/flan-t5-small"
      }
    }
  ]
}
```

2.

```
{
  "resource": {
    "id": "7b4332a5-ba6f-4628-81fa-967fe74b5476",
    "tenant": "dataplane",
    "created_at": "2026-05-12T13:22:02.353393Z",
    "updated_at": "2026-05-12T13:22:25.739139Z",
    "owner": "system:serviceaccount:dataplane:dataplane-sa"
  },
  "status": {
    "state": "failed",
    "message": {
      "message": "Evaluation job is failed. \nBenchmark arc_easy failed with message: Model endpoint returned HTTP 503: 503 Server Error: Service Unavailable for url: http://redhataigranite-31-8b-instruct-team-a.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1/completions\n",
      "message_code": "evaluation_job_updated"
    },
    "benchmarks": [
      {
        "provider_id": "lm_evaluation_harness",
        "id": "arc_easy",
        "benchmark_index": 0,
        "status": "failed",
        "error_message": {
          "message": "Model endpoint returned HTTP 503: 503 Server Error: Service Unavailable for url: http://redhataigranite-31-8b-instruct-team-a.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1/completions",
          "message_code": "model_server_error"
        }
      }
    ]
  },
  "results": {
    "benchmarks": [
      {
        "id": "arc_easy",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 0
      }
    ]
  },
  "name": "model api key/cert test",
  "model": {
    "url": "http://redhataigranite-31-8b-instruct-team-a.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1",
    "name": "redhataigranite-31-8b-instruct"
  },
  "benchmarks": [
    {
      "id": "arc_easy",
      "provider_id": "lm_evaluation_harness",
      "parameters": {
        "limit": 5,
        "num_examples": 1000,
        "tokenizer": "google/flan-t5-small"
      }
    }
  ]
}
```

3.
```
{
  "resource": {
    "id": "647bab90-9794-4922-8232-c3efee4065d9",
    "tenant": "dataplane",
    "created_at": "2026-05-12T13:20:33.45704Z",
    "updated_at": "2026-05-12T13:20:50.077446Z",
    "owner": "system:serviceaccount:dataplane:dataplane-sa"
  },
  "status": {
    "state": "failed",
    "message": {
      "message": "Evaluation job is failed. \nBenchmark arc_easy failed with message: Gated HuggingFace dataset error; authentication required. Set HF_TOKEN by adding an 'hf-token' key to your model auth secret (model.auth.secret_ref).\n",
      "message_code": "evaluation_job_updated"
    },
    "benchmarks": [
      {
        "provider_id": "lm_evaluation_harness",
        "id": "arc_easy",
        "benchmark_index": 0,
        "status": "failed",
        "error_message": {
          "message": "Gated HuggingFace dataset error; authentication required. Set HF_TOKEN by adding an 'hf-token' key to your model auth secret (model.auth.secret_ref).",
          "message_code": "gated_dataset_auth_required"
        }
      }
    ]
  },
  "results": {
    "benchmarks": [
      {
        "id": "arc_easy",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 0
      }
    ]
  },
  "name": "model api key/cert test",
  "model": {
    "url": "https://redhataigranite-31-8b-instruct-team-a.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1",
    "name": "redhataigranite-31-8b-instruct"
  },
  "benchmarks": [
    {
      "id": "arc_easy",
      "provider_id": "lm_evaluation_harness",
      "parameters": {
        "limit": 5,
        "num_examples": 1000,
        "tokenizer": "meta-llama/Llama-3.2-1B-Instruct"
      }
    }
  ]
}

```

4.
```
{
  "resource": {
    "id": "647bab90-9794-4922-8232-c3efee4065d9",
    "tenant": "dataplane",
    "created_at": "2026-05-12T13:20:33.45704Z",
    "updated_at": "2026-05-12T13:20:50.077446Z",
    "owner": "system:serviceaccount:dataplane:dataplane-sa"
  },
  "status": {
    "state": "failed",
    "message": {
      "message": "Evaluation job is failed. \nBenchmark arc_easy failed with message: Gated HuggingFace dataset error; authentication required. Set HF_TOKEN by adding an 'hf-token' key to your model auth secret (model.auth.secret_ref).\n",
      "message_code": "evaluation_job_updated"
    },
    "benchmarks": [
      {
        "provider_id": "lm_evaluation_harness",
        "id": "arc_easy",
        "benchmark_index": 0,
        "status": "failed",
        "error_message": {
          "message": "Gated HuggingFace dataset error; authentication required. Set HF_TOKEN by adding an 'hf-token' key to your model auth secret (model.auth.secret_ref).",
          "message_code": "gated_dataset_auth_required"
        }
      }
    ]
  },
  "results": {
    "benchmarks": [
      {
        "id": "arc_easy",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 0
      }
    ]
  },
  "name": "model api key/cert test",
  "model": {
    "url": "https://redhataigranite-31-8b-instruct-team-a.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1",
    "name": "redhataigranite-31-8b-instruct"
  },
  "benchmarks": [
    {
      "id": "arc_easy",
      "provider_id": "lm_evaluation_harness",
      "parameters": {
        "limit": 5,
        "num_examples": 1000,
        "tokenizer": "meta-llama/Llama-3.2-1B-Instruct"
      }
    }
  ]
}
```

5.
```
{
  "resource": {
    "id": "4955fbf2-4e2f-447d-bd80-044fbb376f7b",
    "tenant": "dataplane",
    "created_at": "2026-05-13T06:26:15.862006Z",
    "updated_at": "2026-05-13T06:26:36.460489Z",
    "owner": "system:serviceaccount:dataplane:dataplane-sa"
  },
  "status": {
    "state": "failed",
    "message": {
      "message": "Evaluation job is failed. \nBenchmark arc_easy failed with message: Model endpoint returned HTTP 404: 404 Client Error: Not Found for url: https://vllm-llama-prabhu.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1/completions\n",
      "message_code": "evaluation_job_updated"
    },
    "benchmarks": [
      {
        "provider_id": "lm_evaluation_harness",
        "id": "arc_easy",
        "benchmark_index": 0,
        "status": "failed",
        "error_message": {
          "message": "Model endpoint returned HTTP 404: 404 Client Error: Not Found for url: https://vllm-llama-prabhu.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1/completions",
          "message_code": "model_endpoint_not_found"
        }
      }
    ]
  },
  "results": {
    "benchmarks": [
      {
        "id": "arc_easy",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 0
      }
    ]
  },
  "name": "arc_easy evaluation",
  "model": {
    "url": "https://vllm-llama-prabhu.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1",
    "name": "gpt2"
  },
  "benchmarks": [
    {
      "id": "arc_easy",
      "provider_id": "lm_evaluation_harness",
      "parameters": {
        "limit": 5,
        "num_examples": 10
      }
    }
  ]
}
```
6.
```
{
  "resource": {
    "id": "0ade03bb-5ee3-420c-88f8-3030061d2be1",
    "tenant": "dataplane",
    "created_at": "2026-05-13T06:27:57.44945Z",
    "updated_at": "2026-05-13T06:28:17.772446Z",
    "owner": "system:serviceaccount:dataplane:dataplane-sa"
  },
  "status": {
    "state": "failed",
    "message": {
      "message": "Evaluation job is failed. \nBenchmark arc_easy failed with message: Evaluation failed: 405 Client Error: Method Not Allowed for url: https://vllm-llama-prabhu.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1/completions\n",
      "message_code": "evaluation_job_updated"
    },
    "benchmarks": [
      {
        "provider_id": "lm_evaluation_harness",
        "id": "arc_easy",
        "benchmark_index": 0,
        "status": "failed",
        "error_message": {
          "message": "Evaluation failed: 405 Client Error: Method Not Allowed for url: https://vllm-llama-prabhu.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1/completions",
          "message_code": "evaluation_failed"
        }
      }
    ]
  },
  "results": {
    "benchmarks": [
      {
        "id": "arc_easy",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 0
      }
    ]
  },
  "name": "arc_easy evaluation",
  "model": {
    "url": "http://vllm-llama-prabhu.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1",
    "name": "gpt2"
  },
  "benchmarks": [
    {
      "id": "arc_easy",
      "provider_id": "lm_evaluation_harness",
      "parameters": {
        "limit": 5,
        "num_examples": 10
      }
    }
  ]
}
```
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate, user-friendly error messages for evaluation run failures
  * Improved detection and reporting for gated dataset and authentication issues
  * Clearer HTTP error classification for endpoint failures (auth, not found, rate limits, server errors)
  * Sanitized error text to avoid exposing sensitive details
<!-- end of auto-generated comment: release notes by coderabbit.ai -->