### PR TITLE
fix: add trust_remote_code to crows_pairs_english and ethics_cm tasks

### DIFF
--- a/lm_eval/tasks/crows_pairs/crows_pairs_english.yaml
+++ b/lm_eval/tasks/crows_pairs/crows_pairs_english.yaml
@@ -1,7 +1,7 @@
 tag:
   - crows_pairs
 task: crows_pairs_english
-dataset_path: BigScienceBiasEval/crows_pairs_multilingual
+dataset_path: jannalu/crows_pairs_multilingual
 dataset_name: english
 test_split: test
 output_type: multiple_choice

--- a/lm_eval/tasks/hendrycks_ethics/commonsense.yaml
+++ b/lm_eval/tasks/hendrycks_ethics/commonsense.yaml
@@ -3,6 +3,10 @@ tag:
 task: ethics_cm
 dataset_path: EleutherAI/hendrycks_ethics
 dataset_name: commonsense
+dataset_kwargs:
+  # Siblings inherit this entire dict via shallow dict.update() (lm_eval/utils.py).
+  # If a sibling needs to add any dataset_kwargs key, it must also repeat this revision pin.
+  revision: a710dd862056df1a92346e7afee93a34d57a5f42
 output_type: multiple_choice
 training_split: train
 test_split: test

--- a/main.py
+++ b/main.py
@@ -37,6 +37,16 @@ _TEST_DATA_DIR = "/test_data"
 # EvalHub mounts the job spec JSON under this directory only; reject other paths (CWE-22).
 _JOB_SPEC_ALLOWED_ROOT = Path("/meta")
 
+# Benchmarks whose HuggingFace datasets use custom loading scripts and require trust_remote_code.
+# Remove an entry here once the dataset is converted to parquet on the Hub.
+_BENCHMARKS_REQUIRING_REMOTE_CODE: frozenset[str] = frozenset({
+    "ethics_cm",
+})
+
+
+def _needs_trust_remote_code(benchmark_id: str) -> bool:
+    return benchmark_id in _BENCHMARKS_REQUIRING_REMOTE_CODE
+
 
 def _resolve_job_spec_path_for_read(path: str) -> Path | None:
     """Return a resolved path to open, or None if ``path`` is invalid or escapes ``/meta``."""
@@ -563,22 +573,32 @@ class LMEvalAdapter(FrameworkAdapter):
                 )
             )
 
+            # Some datasets use custom HF loading scripts and require trust_remote_code.
+            import datasets as _datasets
+            _prev_trust_remote_code = _datasets.config.HF_DATASETS_TRUST_REMOTE_CODE
+            if _needs_trust_remote_code(benchmark_id):
+                _datasets.config.HF_DATASETS_TRUST_REMOTE_CODE = True
+                logger.info("trust_remote_code enabled for benchmark %s", benchmark_id)
+
             # Run evaluation based on job spec
             # Note: batch_size is passed in model_args for local-completions backend
-            results = simple_evaluate(
-                model=model_backend,
-                model_args=model_args,
-                tasks=[benchmark_id],
-                num_fewshot=int(num_fewshot),
-                device="cpu",
-                limit=num_examples,
-                random_seed=random_seed,
-                numpy_random_seed=random_seed,
-                torch_random_seed=random_seed,
-                task_manager=task_manager,
-                log_samples=True,
-                gen_kwargs=gen_kwargs,
-            )
+            try:
+                results = simple_evaluate(
+                    model=model_backend,
+                    model_args=model_args,
+                    tasks=[benchmark_id],
+                    num_fewshot=int(num_fewshot),
+                    device="cpu",
+                    limit=num_examples,
+                    random_seed=random_seed,
+                    numpy_random_seed=random_seed,
+                    torch_random_seed=random_seed,
+                    task_manager=task_manager,
+                    log_samples=True,
+                    gen_kwargs=gen_kwargs,
+                )
+            finally:
+                _datasets.config.HF_DATASETS_TRUST_REMOTE_CODE = _prev_trust_remote_code
 
             # Phase 4: Post-processing
             callbacks.report_status(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
crows_pairs_english and ethics_cm fail with 
```
The repository for BigScienceBiasEval/crows_pairs_multilingual contains custom code which must be executed to correctly load the dataset. You can inspect the repository content at https://hf.co/datasets/BigScienceBiasEval/crows_pairs_multilingual.\nPlease pass the argument `trust_remote_code=True` to allow custom code to be run.",
```
Both datasets use custom Python loading scripts on HuggingFace Hub. The datasets library skips the trust check only if the script is already locally cached but since every pod starts with an empty HF cache, the check fires every time and fails.

Fix: 
1. cherry-pick from upstream PR #3378 (crows_pairs → jannalu)
2. Update the code to set HF_DATASETS_TRUST_REMOTE_CODE for ethics_cm benchmark 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by creating an evaluation job for the failing collection i.e. `safety-and-fairness-v1`
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated source for the CROWS-PAIRS multilingual benchmark configuration.
  * Pinned a specific dataset revision for the Hendrycks Ethics commonsense task to improve reproducibility.

* **Infrastructure Updates**
  * Evaluation flow now detects benchmarks that require remote dataset code and temporarily enables the necessary runtime setting so those datasets evaluate correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Testing:
bbq is still in progress which takes around 4hours when I captured this response.
```
{
  "resource": {
    "id": "aa8b7960-86ed-4006-a20f-3077db140a59",
    "tenant": "dataplane",
    "created_at": "2026-06-03T16:33:08.205731Z",
    "updated_at": "2026-06-03T16:44:13.337449Z",
    "owner": "system:serviceaccount:dataplane:dataplane-sa"
  },
  "status": {
    "state": "running",
    "message": {
      "message": "Evaluation job is running",
      "message_code": "evaluation_job_updated"
    },
    "benchmarks": [
      {
        "provider_id": "lm_evaluation_harness",
        "id": "truthfulqa_mc1",
        "benchmark_index": 0,
        "status": "completed",
        "completed_at": "2026-06-03T16:41:32.617790+00:00"
      },
      {
        "provider_id": "lm_evaluation_harness",
        "id": "bbq",
        "benchmark_index": 4,
        "status": "running"
      },
      {
        "provider_id": "lm_evaluation_harness",
        "id": "ethics_cm",
        "benchmark_index": 5,
        "status": "completed",
        "completed_at": "2026-06-03T16:44:13.317360+00:00"
      },
      {
        "provider_id": "lm_evaluation_harness",
        "id": "winogender",
        "benchmark_index": 2,
        "status": "completed",
        "completed_at": "2026-06-03T16:41:20.903431+00:00"
      },
      {
        "provider_id": "lm_evaluation_harness",
        "id": "crows_pairs_english",
        "benchmark_index": 3,
        "status": "completed",
        "completed_at": "2026-06-03T16:40:45.613293+00:00"
      },
      {
        "provider_id": "lm_evaluation_harness",
        "id": "toxigen",
        "benchmark_index": 1,
        "status": "completed",
        "completed_at": "2026-06-03T16:38:45.703178+00:00"
      }
    ]
  },
  "results": {
    "benchmarks": [
      {
        "id": "toxigen",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 1,
        "metrics": {
          "acc": 0.4074468085106383,
          "acc_norm": 0.42872340425531913,
          "acc_norm_stderr": 0.016150241325972998,
          "acc_stderr": 0.01603490291675187
        },
        "artifacts": {
          "evalhub.env_card": {
            "aggregate_results": {},
            "autograder_bias": {},
            "capture_completeness": 0.15,
            "confidence_intervals": {},
            "cpu_model": "x86_64",
            "custom": {},
            "k8s_pod_labels": {},
            "k8s_resource_limits": {},
            "key_packages": {
              "lm_eval": "0.4.8",
              "torch": "2.6.0",
              "transformers": "4.48.0"
            },
            "os_info": "Linux-5.14.0-570.78.1.el9_6.x86_64-x86_64-with-glibc2.34",
            "per_task_results": {},
            "python_version": "3.11.13",
            "scorer_ids": []
          }
        }
      },
      {
        "id": "crows_pairs_english",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 3,
        "metrics": {
          "likelihood_diff": 3.6793729101979404,
          "likelihood_diff_stderr": 0.08998503026837806,
          "pct_stereotype": 0.5802027429934407,
          "pct_stereotype_stderr": 0.012055151703206032
        },
        "artifacts": {
          "evalhub.env_card": {
            "aggregate_results": {},
            "autograder_bias": {},
            "capture_completeness": 0.15,
            "confidence_intervals": {},
            "cpu_model": "x86_64",
            "custom": {},
            "k8s_pod_labels": {},
            "k8s_resource_limits": {},
            "key_packages": {
              "lm_eval": "0.4.8",
              "torch": "2.6.0",
              "transformers": "4.48.0"
            },
            "os_info": "Linux-5.14.0-570.78.1.el9_6.x86_64-x86_64-with-glibc2.34",
            "per_task_results": {},
            "python_version": "3.11.13",
            "scorer_ids": []
          }
        }
      },
      {
        "id": "winogender",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 2,
        "artifacts": {
          "evalhub.env_card": {
            "aggregate_results": {},
            "autograder_bias": {},
            "capture_completeness": 0.15,
            "confidence_intervals": {},
            "cpu_model": "x86_64",
            "custom": {},
            "k8s_pod_labels": {},
            "k8s_resource_limits": {},
            "key_packages": {
              "lm_eval": "0.4.8",
              "torch": "2.6.0",
              "transformers": "4.48.0"
            },
            "os_info": "Linux-5.14.0-570.78.1.el9_6.x86_64-x86_64-with-glibc2.34",
            "per_task_results": {},
            "python_version": "3.11.13",
            "scorer_ids": []
          }
        }
      },
      {
        "id": "truthfulqa_mc1",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 0,
        "metrics": {
          "acc": 0.2729498164014688,
          "acc_stderr": 0.01559475363200653
        },
        "artifacts": {
          "evalhub.env_card": {
            "aggregate_results": {},
            "autograder_bias": {},
            "capture_completeness": 0.15,
            "confidence_intervals": {},
            "cpu_model": "x86_64",
            "custom": {},
            "k8s_pod_labels": {},
            "k8s_resource_limits": {},
            "key_packages": {
              "lm_eval": "0.4.8",
              "torch": "2.6.0",
              "transformers": "4.48.0"
            },
            "os_info": "Linux-5.14.0-570.78.1.el9_6.x86_64-x86_64-with-glibc2.34",
            "per_task_results": {},
            "python_version": "3.11.13",
            "scorer_ids": []
          }
        }
      },
      {
        "id": "ethics_cm",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 5,
        "metrics": {
          "acc": 0.5305019305019305,
          "acc_stderr": 0.008007939421504733
        },
        "artifacts": {
          "evalhub.env_card": {
            "aggregate_results": {},
            "autograder_bias": {},
            "capture_completeness": 0.15,
            "confidence_intervals": {},
            "cpu_model": "x86_64",
            "custom": {},
            "k8s_pod_labels": {},
            "k8s_resource_limits": {},
            "key_packages": {
              "lm_eval": "0.4.8",
              "torch": "2.6.0",
              "transformers": "4.48.0"
            },
            "os_info": "Linux-5.14.0-570.78.1.el9_6.x86_64-x86_64-with-glibc2.34",
            "per_task_results": {},
            "python_version": "3.11.13",
            "scorer_ids": []
          }
        }
      }
    ]
  },
  "name": "model test using collection safety-and-fairness-v1",
  "model": {
    "url": "https://vllm-llama-prabhu.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1",
    "name": "meta-llama/Llama-3.2-1B-Instruct",
    "auth": {
      "secret_ref": "hf-token-key"
    }
  },
  "collection": {
    "id": "safety-and-fairness-v1"
  }
}
```