### PR TITLE
cherry-pick: add trust_remote_code to crows_pairs_english and ethics_cm tasks

### DIFF
--- a/lm_eval/tasks/crows_pairs/crows_pairs_english.yaml
+++ b/lm_eval/tasks/crows_pairs/crows_pairs_english.yaml
@@ -1,7 +1,7 @@
 tag:
   - crows_pairs
 task: crows_pairs_english
-dataset_path: BigScienceBiasEval/crows_pairs_multilingual
+dataset_path: jannalu/crows_pairs_multilingual
 dataset_name: english
 test_split: test
 output_type: multiple_choice

--- a/lm_eval/tasks/hendrycks_ethics/commonsense.yaml
+++ b/lm_eval/tasks/hendrycks_ethics/commonsense.yaml
@@ -3,6 +3,10 @@ tag:
 task: ethics_cm
 dataset_path: EleutherAI/hendrycks_ethics
 dataset_name: commonsense
+dataset_kwargs:
+  # Siblings inherit this entire dict via shallow dict.update() (lm_eval/utils.py).
+  # If a sibling needs to add any dataset_kwargs key, it must also repeat this revision pin.
+  revision: a710dd862056df1a92346e7afee93a34d57a5f42
 output_type: multiple_choice
 training_split: train
 test_split: test

--- a/main.py
+++ b/main.py
@@ -37,6 +37,16 @@ _TEST_DATA_DIR = "/test_data"
 # EvalHub mounts the job spec JSON under this directory only; reject other paths (CWE-22).
 _JOB_SPEC_ALLOWED_ROOT = Path("/meta")
 
+# Benchmarks whose HuggingFace datasets use custom loading scripts and require trust_remote_code.
+# Remove an entry here once the dataset is converted to parquet on the Hub.
+_BENCHMARKS_REQUIRING_REMOTE_CODE: frozenset[str] = frozenset({
+    "ethics_cm",
+})
+
+
+def _needs_trust_remote_code(benchmark_id: str) -> bool:
+    return benchmark_id in _BENCHMARKS_REQUIRING_REMOTE_CODE
+
 
 def _resolve_job_spec_path_for_read(path: str) -> Path | None:
     """Return a resolved path to open, or None if ``path`` is invalid or escapes ``/meta``."""
@@ -563,22 +573,32 @@ class LMEvalAdapter(FrameworkAdapter):
                 )
             )
 
+            # Some datasets use custom HF loading scripts and require trust_remote_code.
+            import datasets as _datasets
+            _prev_trust_remote_code = _datasets.config.HF_DATASETS_TRUST_REMOTE_CODE
+            if _needs_trust_remote_code(benchmark_id):
+                _datasets.config.HF_DATASETS_TRUST_REMOTE_CODE = True
+                logger.info("trust_remote_code enabled for benchmark %s", benchmark_id)
+
             # Run evaluation based on job spec
             # Note: batch_size is passed in model_args for local-completions backend
-            results = simple_evaluate(
-                model=model_backend,
-                model_args=model_args,
-                tasks=[benchmark_id],
-                num_fewshot=int(num_fewshot),
-                device="cpu",
-                limit=num_examples,
-                random_seed=random_seed,
-                numpy_random_seed=random_seed,
-                torch_random_seed=random_seed,
-                task_manager=task_manager,
-                log_samples=True,
-                gen_kwargs=gen_kwargs,
-            )
+            try:
+                results = simple_evaluate(
+                    model=model_backend,
+                    model_args=model_args,
+                    tasks=[benchmark_id],
+                    num_fewshot=int(num_fewshot),
+                    device="cpu",
+                    limit=num_examples,
+                    random_seed=random_seed,
+                    numpy_random_seed=random_seed,
+                    torch_random_seed=random_seed,
+                    task_manager=task_manager,
+                    log_samples=True,
+                    gen_kwargs=gen_kwargs,
+                )
+            finally:
+                _datasets.config.HF_DATASETS_TRUST_REMOTE_CODE = _prev_trust_remote_code
 
             # Phase 4: Post-processing
             callbacks.report_status(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
crows_pairs_english and ethics_cm fail with

The repository for BigScienceBiasEval/crows_pairs_multilingual contains custom code which must be executed to correctly load the dataset. You can inspect the repository content at https://hf.co/datasets/BigScienceBiasEval/crows_pairs_multilingual.\nPlease pass the argument `trust_remote_code=True` to allow custom code to be run.",
Both datasets use custom Python loading scripts on HuggingFace Hub. The datasets library skips the trust check only if the script is already locally cached but since every pod starts with an empty HF cache, the check fires every time and fails.

Fix:
cherry-pick from upstream PR https://github.com/EleutherAI/lm-evaluation-harness/pull/3378 (crows_pairs → jannalu)
Update the code to set HF_DATASETS_TRUST_REMOTE_CODE for ethics_cm benchmark

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by creating an evaluation job for the failing collection i.e. safety-and-fairness-v1

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
