### PR TITLE
Fix version in pyproject.toml for AIPCC release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lm_eval"
-version = "0.4.12.dev0"
+version = "0.4.12"
 authors = [
     { name = "EleutherAI", email = "contact@eleuther.ai" }
 ]


### PR DESCRIPTION
Change version from "0.4.12.dev0" to "0.4.12" to enable proper AIPCC package building. The .dev0 suffix prevents the builder from creating tagged releases.

This is an interim fix for midstream while we work with upstream EleutherAI to address their versioning convention.

Once fixed, this allows creating tag v0.4.12+rhaiv.1 that matches the pyproject.toml version for AIPCC onboarding.

Related: AIPCC-18780, RHOAIENG-69300

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to `0.4.12` for the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->