### PR TITLE
Add eval-hub-sdk[adapter]==0.4.2 as required dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,8 @@ tasks = [
     "lm_eval[multilingual]",
     "lm_eval[ruler]",
 ]
+# Red Hat OpenShift AI specific dependencies
+rhoai = ["eval-hub-sdk[adapter]==0.4.2"]
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
Add eval-hub-sdk with adapter extra to enable EvalHub integration. This is a top-level dependency required for AIPCC to track and build new versions.

Related: AIPCC-18780, RHOAIENG-69300

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
