### PR TITLE
feat(adapter): align JobStatusUpdate with SDK — drop unused fields

### DIFF
--- a/main.py
+++ b/main.py
@@ -215,7 +215,6 @@ def _seed_hf_offline_before_lm_eval_import() -> None:
 
 from evalhub.adapter import (
     DefaultCallbacks,
-    ErrorInfo,
     EvaluationResult,
     FrameworkAdapter,
     JobCallbacks,
@@ -258,12 +257,8 @@ def _jsonable(value: Any) -> Any:
     return str(value)
 
 
-def _status_message(text: str, code: str = "status_update") -> MessageInfo:
-    return MessageInfo(message=text, message_code=code)
-
-
 def _sanitize_error_message(msg: str) -> str:
-    """Redact secrets from error text before Eval Hub callbacks (ErrorInfo.message)."""
+    """Redact secrets from error text before Eval Hub callbacks."""
     s = msg
 
     # Authorization header / Bearer fragments (case-insensitive)
@@ -525,10 +520,6 @@ class LMEvalAdapter(FrameworkAdapter):
                 JobStatusUpdate(
                     status=JobStatus.RUNNING,
                     phase=JobPhase.INITIALIZING,
-                    progress=0.0,
-                    message=_status_message(
-                        f"Initializing evaluation for {benchmark_id}"
-                    ),
                 )
             )
 
@@ -545,10 +536,6 @@ class LMEvalAdapter(FrameworkAdapter):
                 JobStatusUpdate(
                     status=JobStatus.RUNNING,
                     phase=JobPhase.LOADING_DATA,
-                    progress=0.1,
-                    message=_status_message(
-                        f"Loading benchmark data for {benchmark_id}"
-                    ),
                 )
             )
 
@@ -560,8 +547,6 @@ class LMEvalAdapter(FrameworkAdapter):
                 JobStatusUpdate(
                     status=JobStatus.RUNNING,
                     phase=JobPhase.RUNNING_EVALUATION,
-                    progress=0.2,
-                    message=_status_message(f"Running evaluation on {model_name}"),
                 )
             )
 
@@ -597,8 +582,6 @@ class LMEvalAdapter(FrameworkAdapter):
                 JobStatusUpdate(
                     status=JobStatus.RUNNING,
                     phase=JobPhase.POST_PROCESSING,
-                    progress=0.8,
-                    message=_status_message("Processing evaluation results"),
                 )
             )
 
@@ -696,8 +679,6 @@ class LMEvalAdapter(FrameworkAdapter):
                 JobStatusUpdate(
                     status=JobStatus.RUNNING,
                     phase=JobPhase.PERSISTING_ARTIFACTS,
-                    progress=0.9,
-                    message=_status_message("Persisting evaluation artifacts"),
                 )
             )
 
@@ -748,10 +729,7 @@ class LMEvalAdapter(FrameworkAdapter):
             callbacks.report_status(
                 JobStatusUpdate(
                     status=JobStatus.FAILED,
-                    phase=JobPhase.COMPLETED,
-                    progress=0.0,
-                    message=_status_message("Evaluation failed", code=error_code),
-                    error=ErrorInfo(
+                    error_message=MessageInfo(
                         message=error_message,
                         message_code=error_code,
                     ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Cherry pick https://github.com/opendatahub-io/lm-evaluation-harness/pull/176 from incubation to stable branch


Align JobStatusUpdate usage with the current evalhub SDK contract.

Changes:

Remove progress and message from all JobStatusUpdate calls — the SDK's report_status does not forward these fields to the server (BenchmarkStatusEvent schema has no corresponding keys), so they were silently dropped.
Replace deprecated ErrorInfo with MessageInfo on the failure path — the SDK marks error: ErrorInfo as deprecated in favour of error_message: MessageInfo, which is the field actually serialized and sent to the server.
Drop phase=JobPhase.COMPLETED from the failure status update — the server's state-transition logic keys on status alone; phase is not read or acted upon for FAILED events. The COMPLETED phase for successful runs is already handled by report_results in the SDK.
Remove unused _status_message helper and ErrorInfo import — no remaining callers after the above changes.
All five success-path phases (INITIALIZING, LOADING_DATA, RUNNING_EVALUATION,
POST_PROCESSING, PERSISTING_ARTIFACTS) remain unchanged and are emitted in order.

Jira issue: https://redhat.atlassian.net/browse/RHOAIENG-66845

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

╰─➤  uv run pytest tests/test_evalhub_error_sanitize.py tests/test_job_spec_parameters_path.py tests/test_adapter_offline_inference.py
================================= test session starts =================================
platform darwin -- Python 3.12.12, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/gnaulak/workspace/worktrees/lm-evaluation-harness/stable-cherry-pick
configfile: pyproject.toml
plugins: anyio-4.14.2
collected 28 items

tests/test_evalhub_error_sanitize.py ...............                            [ 53%]
tests/test_job_spec_parameters_path.py ......                                   [ 75%]
tests/test_adapter_offline_inference.py .......                                 [100%]

================================== warnings summary ===================================
.venv/lib/python3.12/site-packages/requests/__init__.py:113
  /Users/gnaulak/workspace/worktrees/lm-evaluation-harness/stable-cherry-pick/.venv/lib/python3.12/site-packages/requests/__init__.py:113: RequestsDependencyWarning: urllib3 (2.6.3) or chardet (6.0.0.post1)/charset_normalizer (3.4.9) doesn't match a supported version!
    warnings.warn(

.venv/lib/python3.12/site-packages/olot/oci/oci_image_manifest.py:100
  /Users/gnaulak/workspace/worktrees/lm-evaluation-harness/stable-cherry-pick/.venv/lib/python3.12/site-packages/olot/oci/oci_image_manifest.py:100: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.13/migration/
    class ContentDescriptor(BaseModel):

.venv/lib/python3.12/site-packages/olot/oci/oci_image_layout.py:17
  /Users/gnaulak/workspace/worktrees/lm-evaluation-harness/stable-cherry-pick/.venv/lib/python3.12/site-packages/olot/oci/oci_image_layout.py:17: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.13/migration/
    class OCIImageLayout(BaseModel):

lm_eval/filters/extraction.py:99
  /Users/gnaulak/workspace/worktrees/lm-evaluation-harness/stable-cherry-pick/lm_eval/filters/extraction.py:99: SyntaxWarning: invalid escape sequence '\s'
    - step 2 : We parse the choice with regex :[\s]*([A-?]), where ? varies by number of choices.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== 28 passed, 4 warnings in 37.72s ===========================

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
