### PR TITLE
fix: skip non-finite metric values before reporting results

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,6 +24,7 @@ files and do not call the Hub. You do not need ``parameters.offline``.
 
 import json
 import logging
+import math
 import os
 import re
 import requests
@@ -266,6 +267,23 @@ def _jsonable(value: Any) -> Any:
     if isinstance(value, (list, tuple)):
         return [_jsonable(v) for v in value]
     return str(value)
+
+
+def _to_finite_float(metric_value: Any) -> float | None:
+    """Return a finite float, or None for N/A / non-numeric / NaN / Inf.
+
+    BBQ category bias aggregators return NaN when a category has no examples
+    (common with num_examples/limit); those must not become EvaluationResults.
+    """
+    if metric_value == "N/A" or metric_value is None:
+        return None
+    try:
+        value = float(metric_value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(value):
+        return None
+    return value
 
 
 def _sanitize_error_message(msg: str) -> str:
@@ -779,8 +797,11 @@ class LMEvalAdapter(FrameworkAdapter):
                                 continue
                             if metric_value == "N/A" or metric_value is None:
                                 continue
+                            value = _to_finite_float(metric_value)
+                            if value is None:
+                                continue
                             clean, _, _ = metric_name.rpartition(",")
-                            subtask_metrics[clean] = subtask_metrics.get(clean, 0) + float(metric_value)
+                            subtask_metrics[clean] = subtask_metrics.get(clean, 0) + value
                             subtask_count[clean] = subtask_count.get(clean, 0) + 1
                     task_results = {
                         f"{k},none": subtask_metrics[k] / subtask_count[k]
@@ -801,9 +822,8 @@ class LMEvalAdapter(FrameworkAdapter):
                         clean_metric,
                     )
                     continue
-                try:
-                    value = float(metric_value)
-                except (TypeError, ValueError):
+                value = _to_finite_float(metric_value)
+                if value is None:
                     continue
                 existing = metric_candidates.get(clean_metric)
                 if existing is None or filter_name == "none":

--- a/main.py
+++ b/main.py
@@ -279,7 +279,7 @@ def _to_finite_float(metric_value: Any) -> float | None:
         return None
     try:
         value = float(metric_value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return None
     if not math.isfinite(value):
         return None

--- a/tests/test_metric_candidates.py
+++ b/tests/test_metric_candidates.py
@@ -1,5 +1,7 @@
 """Unit tests for skipping non-finite lm-eval metric values (BBQ NaN/Inf)."""
 
+from decimal import Decimal
+
 import pytest
 
 from main import _to_finite_float
@@ -17,6 +19,7 @@ from main import _to_finite_float
         (float("inf"), None),
         (float("-inf"), None),
         ("not-a-number", None),
+        (Decimal("1e10000"), None),  # float() raises OverflowError
     ],
 )
 def test_to_finite_float(raw: object, expected: float | None) -> None:

--- a/tests/test_metric_candidates.py
+++ b/tests/test_metric_candidates.py
@@ -1,0 +1,27 @@
+"""Unit tests for skipping non-finite lm-eval metric values (BBQ NaN/Inf)."""
+
+import pytest
+
+from main import _to_finite_float
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (0.9, 0.9),
+        (1, 1.0),
+        ("0.5", 0.5),
+        ("N/A", None),
+        (None, None),
+        (float("nan"), None),
+        (float("inf"), None),
+        (float("-inf"), None),
+        ("not-a-number", None),
+    ],
+)
+def test_to_finite_float(raw: object, expected: float | None) -> None:
+    got = _to_finite_float(raw)
+    if expected is None:
+        assert got is None
+    else:
+        assert got == pytest.approx(expected)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Problem:
BBQ was failing with Failed to save to MLflow: Out of range float values are not JSON compliant/Failed to send results to evalhub: Out of range float values are not JSON compliant when users set a small num_examples.
https://redhat.atlassian.net/browse/RHOAIENG-79800

## Description
<!--- Describe your changes in detail -->

- Skip NaN/Inf (and other non-finite) metric values when building `EvaluationResult`s from lm-eval output.
- BBQ category bias aggregators return NaN when a category has no examples (common with `num_examples`/limit); those values break JSON and MLflow serialization.
- Add unit tests for `_to_finite_float`.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested the bbq benchmark with the fix, evaluation went fine and the metrics are stored properly in evaluation meta and MLFlow.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


Now, bbq benchmark execution went fine both with/with out MLFlow.

With MLFlow:
```
{
  "resource": {
    "id": "16e7ef16-aa84-4406-b049-b2e4286ac228",
    "tenant": "tenant",
    "created_at": "2026-07-30T08:23:28.445403Z",
    "updated_at": "2026-07-30T08:26:08.488822Z",
    "owner": "system:serviceaccount:tenant:tenant-user",
    "mlflow_experiment_id": "10"
  },
  "status": {
    "state": "completed",
    "message": {
      "message": "Evaluation job is completed",
      "message_code": "evaluation_job_updated",
      "message_origin": "server"
    },
    "benchmarks": [
      {
        "provider_id": "lm_evaluation_harness",
        "id": "crows_pairs_english",
        "benchmark_index": 3,
        "status": "completed",
        "completed_at": "2026-07-30T08:25:29.197051+00:00"
      },
      {
        "provider_id": "lm_evaluation_harness",
        "id": "truthfulqa_mc1",
        "benchmark_index": 0,
        "status": "completed",
        "completed_at": "2026-07-30T08:25:30.844460+00:00"
      },
      {
        "provider_id": "lm_evaluation_harness",
        "id": "winogender",
        "benchmark_index": 2,
        "status": "completed",
        "completed_at": "2026-07-30T08:25:34.420902+00:00"
      },
      {
        "provider_id": "lm_evaluation_harness",
        "id": "ethics_cm",
        "benchmark_index": 5,
        "status": "completed",
        "completed_at": "2026-07-30T08:25:44.408186+00:00"
      },
      {
        "provider_id": "lm_evaluation_harness",
        "id": "bbq",
        "benchmark_index": 4,
        "status": "completed",
        "completed_at": "2026-07-30T08:26:08.366179+00:00"
      },
      {
        "provider_id": "lm_evaluation_harness",
        "id": "toxigen",
        "benchmark_index": 1,
        "status": "completed",
        "completed_at": "2026-07-30T08:25:31.607466+00:00"
      }
    ]
  },
  "results": {
    "benchmarks": [
      {
        "id": "crows_pairs_english",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 3,
        "metrics": {
          "likelihood_diff": 2.521317640261259,
          "likelihood_diff_stderr": 0.4945229161416541,
          "pct_stereotype": 0.6,
          "pct_stereotype_stderr": 0.1632993161855452
        },
        "additional_info": {
          "batch_size": 1,
          "dataset": [
            {
              "hf_repo": "jannalu/crows_pairs_multilingual",
              "hf_subset": "english",
              "sha": "3550adcf6ac84fc021c0cd99114acd35e1f8b88d"
            }
          ],
          "dataset_split": "test",
          "evaluation_date": "2026-07-30T08:25:23.927097+00:00",
          "hf_offline": false,
          "limit": 10,
          "lmeval_version": "0.4.8",
          "num_concurrent": 1,
          "num_fewshot": 0,
          "num_samples_effective": 10,
          "num_samples_original": 1677,
          "output_type": "multiple_choice",
          "primary_metric": "likelihood_diff",
          "random_seed": 42,
          "tags": [
            "crows_pairs"
          ],
          "task_version": 1,
          "timeout_seconds": 300,
          "tokenizer": "meta-llama/Llama-3.2-1B-Instruct",
          "zero_shot": 2.521317640261259
        },
        "artifacts": {
          "evalhub.env_card": {
            "aggregate_results": {},
            "autograder_bias": {},
            "capture_completeness": 0.15,
            "confidence_intervals": {},
            "cpu_model": "x86_64",
            "custom": {},
            "k8s_pod_labels": {},
            "k8s_resource_limits": {},
            "key_packages": {
              "lm_eval": "0.4.8",
              "torch": "2.6.0",
              "transformers": "4.48.0"
            },
            "os_info": "Linux-5.14.0-570.78.1.el9_6.x86_64-x86_64-with-glibc2.34",
            "per_task_results": {},
            "python_version": "3.11.13",
            "scorer_ids": []
          }
        },
        "mlflow_run_id": "6172447203cc46f6bb61d786ca2a0a52"
      },
      {
        "id": "truthfulqa_mc1",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 0,
        "metrics": {
          "acc": 0.4,
          "acc_stderr": 0.16329931618554522
        },
        "additional_info": {
          "batch_size": 1,
          "dataset": [
            {
              "hf_repo": "truthful_qa",
              "hf_subset": "multiple_choice",
              "sha": "741b8276f2d1982aa3d5b832d3ee81ed3b896490"
            }
          ],
          "evaluation_date": "2026-07-30T08:25:24.199385+00:00",
          "hf_offline": false,
          "limit": 10,
          "lmeval_version": "0.4.8",
          "num_concurrent": 1,
          "num_fewshot": 0,
          "num_samples_effective": 10,
          "num_samples_original": 817,
          "output_type": "multiple_choice",
          "primary_metric": "acc",
          "random_seed": 42,
          "tags": [
            "truthfulqa"
          ],
          "task_version": 2,
          "timeout_seconds": 300,
          "tokenizer": "meta-llama/Llama-3.2-1B-Instruct",
          "zero_shot": 0.4
        },
        "artifacts": {
          "evalhub.env_card": {
            "aggregate_results": {},
            "autograder_bias": {},
            "capture_completeness": 0.15,
            "confidence_intervals": {},
            "cpu_model": "x86_64",
            "custom": {},
            "k8s_pod_labels": {},
            "k8s_resource_limits": {},
            "key_packages": {
              "lm_eval": "0.4.8",
              "torch": "2.6.0",
              "transformers": "4.48.0"
            },
            "os_info": "Linux-5.14.0-570.78.1.el9_6.x86_64-x86_64-with-glibc2.34",
            "per_task_results": {},
            "python_version": "3.11.13",
            "scorer_ids": []
          }
        },
        "mlflow_run_id": "c11b0e11194e4f5e986e54c17d03a3a9"
      },
      {
        "id": "toxigen",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 1,
        "metrics": {
          "acc": 0.7,
          "acc_norm": 0.4,
          "acc_norm_stderr": 0.16329931618554522,
          "acc_stderr": 0.15275252316519466
        },
        "additional_info": {
          "batch_size": 1,
          "dataset": [
            {
              "hf_repo": "skg/toxigen-data",
              "hf_subset": "annotated",
              "sha": "ea082a8973a287097b17973343576e0c8da8eb3b"
            }
          ],
          "dataset_split": "test",
          "evaluation_date": "2026-07-30T08:25:25.725111+00:00",
          "hf_offline": false,
          "limit": 10,
          "lmeval_version": "0.4.8",
          "num_concurrent": 1,
          "num_fewshot": 0,
          "num_samples_effective": 10,
          "num_samples_original": 940,
          "output_type": "multiple_choice",
          "primary_metric": "acc",
          "random_seed": 42,
          "task_version": 1,
          "timeout_seconds": 300,
          "tokenizer": "meta-llama/Llama-3.2-1B-Instruct",
          "zero_shot": 0.7
        },
        "artifacts": {
          "evalhub.env_card": {
            "aggregate_results": {},
            "autograder_bias": {},
            "capture_completeness": 0.15,
            "confidence_intervals": {},
            "cpu_model": "x86_64",
            "custom": {},
            "k8s_pod_labels": {},
            "k8s_resource_limits": {},
            "key_packages": {
              "lm_eval": "0.4.8",
              "torch": "2.6.0",
              "transformers": "4.48.0"
            },
            "os_info": "Linux-5.14.0-570.78.1.el9_6.x86_64-x86_64-with-glibc2.34",
            "per_task_results": {},
            "python_version": "3.11.13",
            "scorer_ids": []
          }
        },
        "mlflow_run_id": "eb3df2ccfb874bf8b177a15707d7742a"
      },
      {
        "id": "winogender",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 2,
        "additional_info": {
          "batch_size": 1,
          "evaluation_date": "2026-07-30T08:25:24.383677+00:00",
          "hf_offline": false,
          "limit": 10,
          "lmeval_version": "0.4.8",
          "num_concurrent": 1,
          "num_fewshot": 0,
          "random_seed": 42,
          "timeout_seconds": 300,
          "tokenizer": "meta-llama/Llama-3.2-1B-Instruct"
        },
        "artifacts": {
          "evalhub.env_card": {
            "aggregate_results": {},
            "autograder_bias": {},
            "capture_completeness": 0.15,
            "confidence_intervals": {},
            "cpu_model": "x86_64",
            "custom": {},
            "k8s_pod_labels": {},
            "k8s_resource_limits": {},
            "key_packages": {
              "lm_eval": "0.4.8",
              "torch": "2.6.0",
              "transformers": "4.48.0"
            },
            "os_info": "Linux-5.14.0-570.78.1.el9_6.x86_64-x86_64-with-glibc2.34",
            "per_task_results": {},
            "python_version": "3.11.13",
            "scorer_ids": []
          }
        },
        "mlflow_run_id": "568353a8dd4e438d9a3d24e0ff8d1b19"
      },
      {
        "id": "ethics_cm",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 5,
        "metrics": {
          "acc": 0.6,
          "acc_stderr": 0.16329931618554522
        },
        "additional_info": {
          "batch_size": 1,
          "dataset": [
            {
              "hf_repo": "EleutherAI/hendrycks_ethics",
              "hf_subset": "commonsense"
            }
          ],
          "dataset_split": "test",
          "evaluation_date": "2026-07-30T08:25:24.922278+00:00",
          "hf_offline": false,
          "limit": 10,
          "lmeval_version": "0.4.8",
          "num_concurrent": 1,
          "num_fewshot": 0,
          "num_samples_effective": 10,
          "num_samples_original": 3885,
          "output_type": "multiple_choice",
          "primary_metric": "acc",
          "random_seed": 42,
          "tags": [
            "hendrycks_ethics"
          ],
          "task_version": 1,
          "timeout_seconds": 300,
          "tokenizer": "meta-llama/Llama-3.2-1B-Instruct",
          "zero_shot": 0.6
        },
        "artifacts": {
          "evalhub.env_card": {
            "aggregate_results": {},
            "autograder_bias": {},
            "capture_completeness": 0.15,
            "confidence_intervals": {},
            "cpu_model": "x86_64",
            "custom": {},
            "k8s_pod_labels": {},
            "k8s_resource_limits": {},
            "key_packages": {
              "lm_eval": "0.4.8",
              "torch": "2.6.0",
              "transformers": "4.48.0"
            },
            "os_info": "Linux-5.14.0-570.78.1.el9_6.x86_64-x86_64-with-glibc2.34",
            "per_task_results": {},
            "python_version": "3.11.13",
            "scorer_ids": []
          }
        },
        "mlflow_run_id": "48fedb379da54479bee9b03e09fc4bb8"
      },
      {
        "id": "bbq",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 4,
        "metrics": {
          "acc": 0.3,
          "acc_stderr": 0.15275252316519466,
          "accuracy_amb": 0,
          "accuracy_disamb": 0.6,
          "amb_bias_score": 0.19999999999999996,
          "amb_bias_score_Age": 0.19999999999999996,
          "disamb_bias_score": -0.19999999999999996,
          "disamb_bias_score_Age": -0.19999999999999996
        },
        "additional_info": {
          "batch_size": 1,
          "dataset": [
            {
              "hf_repo": "oskarvanderwal/bbq",
              "hf_subset": "All",
              "sha": "ab00114b0fbf59c7c539ff9158f6ce717d13ab63"
            }
          ],
          "dataset_split": "test",
          "evaluation_date": "2026-07-30T08:25:25.633624+00:00",
          "hf_offline": false,
          "limit": 10,
          "lmeval_version": "0.4.8",
          "num_concurrent": 1,
          "num_fewshot": 0,
          "num_samples_effective": 10,
          "num_samples_original": 58492,
          "output_type": "multiple_choice",
          "primary_metric": "acc",
          "random_seed": 42,
          "tags": [
            "social_bias"
          ],
          "task_version": 1,
          "timeout_seconds": 300,
          "tokenizer": "meta-llama/Llama-3.2-1B-Instruct",
          "zero_shot": 0.3
        },
        "artifacts": {
          "evalhub.env_card": {
            "aggregate_results": {},
            "autograder_bias": {},
            "capture_completeness": 0.15,
            "confidence_intervals": {},
            "cpu_model": "x86_64",
            "custom": {},
            "k8s_pod_labels": {},
            "k8s_resource_limits": {},
            "key_packages": {
              "lm_eval": "0.4.8",
              "torch": "2.6.0",
              "transformers": "4.48.0"
            },
            "os_info": "Linux-5.14.0-570.78.1.el9_6.x86_64-x86_64-with-glibc2.34",
            "per_task_results": {},
            "python_version": "3.11.13",
            "scorer_ids": []
          }
        },
        "mlflow_run_id": "e9ec617a3e924b53b3e92f2c911b690b"
      }
    ],
    "mlflow_experiment_url": "https://mlflow.opendatahub.svc.cluster.local:8443/api/2.0/mlflow/experiments"
  },
  "name": "model test using collection",
  "model": {
    "url": "https://vllm-llama-prabhu.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1",
    "name": "meta-llama/Llama-3.2-1B-Instruct",
    "auth": {
      "secret_ref": "vllm-api-key"
    }
  },
  "collection": {
    "id": "safety-and-fairness-v1",
    "benchmarks": [
      {
        "id": "bbq",
        "provider_id": "lm_evaluation_harness",
        "parameters": {
          "num_examples": 10
        }
      },
      {
        "id": "crows_pairs_english",
        "provider_id": "lm_evaluation_harness",
        "parameters": {
          "num_examples": 10
        }
      },
      {
        "id": "ethics_cm",
        "provider_id": "lm_evaluation_harness",
        "parameters": {
          "num_examples": 10
        }
      },
      {
        "id": "toxigen",
        "provider_id": "lm_evaluation_harness",
        "parameters": {
          "num_examples": 10
        }
      },
      {
        "id": "winogender",
        "provider_id": "lm_evaluation_harness",
        "parameters": {
          "num_examples": 10
        }
      },
      {
        "id": "truthfulqa_mc1",
        "provider_id": "lm_evaluation_harness",
        "parameters": {
          "num_examples": 10
        }
      }
    ]
  },
  "experiment": {
    "name": "test_exp"
  }
}
```
With out MLFlow:
```
{
  "resource": {
    "id": "3c0d29cb-fbd9-404c-9465-4b3a8b14b903",
    "tenant": "tenant",
    "created_at": "2026-07-30T08:35:18.911335Z",
    "updated_at": "2026-07-30T08:36:22.634352Z",
    "owner": "system:serviceaccount:tenant:tenant-user"
  },
  "status": {
    "state": "completed",
    "message": {
      "message": "Evaluation job is completed",
      "message_code": "evaluation_job_updated",
      "message_origin": "server"
    },
    "benchmarks": [
      {
        "provider_id": "lm_evaluation_harness",
        "id": "truthfulqa_mc1",
        "benchmark_index": 0,
        "status": "completed",
        "completed_at": "2026-07-30T08:35:41.707873+00:00"
      },
      {
        "provider_id": "lm_evaluation_harness",
        "id": "toxigen",
        "benchmark_index": 1,
        "status": "completed",
        "completed_at": "2026-07-30T08:35:40.557718+00:00"
      },
      {
        "provider_id": "lm_evaluation_harness",
        "id": "winogender",
        "benchmark_index": 2,
        "status": "completed",
        "completed_at": "2026-07-30T08:35:45.998661+00:00"
      },
      {
        "provider_id": "lm_evaluation_harness",
        "id": "crows_pairs_english",
        "benchmark_index": 3,
        "status": "completed",
        "completed_at": "2026-07-30T08:35:42.812339+00:00"
      },
      {
        "provider_id": "lm_evaluation_harness",
        "id": "bbq",
        "benchmark_index": 4,
        "status": "completed",
        "completed_at": "2026-07-30T08:36:22.618588+00:00"
      },
      {
        "provider_id": "lm_evaluation_harness",
        "id": "ethics_cm",
        "benchmark_index": 5,
        "status": "completed",
        "completed_at": "2026-07-30T08:35:47.613076+00:00"
      }
    ]
  },
  "results": {
    "benchmarks": [
      {
        "id": "toxigen",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 1,
        "metrics": {
          "acc": 0.7,
          "acc_norm": 0.4,
          "acc_norm_stderr": 0.16329931618554522,
          "acc_stderr": 0.15275252316519466
        },
        "additional_info": {
          "batch_size": 1,
          "dataset": [
            {
              "hf_repo": "skg/toxigen-data",
              "hf_subset": "annotated",
              "sha": "ea082a8973a287097b17973343576e0c8da8eb3b"
            }
          ],
          "dataset_split": "test",
          "evaluation_date": "2026-07-30T08:35:35.317074+00:00",
          "hf_offline": false,
          "limit": 10,
          "lmeval_version": "0.4.8",
          "num_concurrent": 1,
          "num_fewshot": 0,
          "num_samples_effective": 10,
          "num_samples_original": 940,
          "output_type": "multiple_choice",
          "primary_metric": "acc",
          "random_seed": 42,
          "task_version": 1,
          "timeout_seconds": 300,
          "tokenizer": "meta-llama/Llama-3.2-1B-Instruct",
          "zero_shot": 0.7
        },
        "artifacts": {
          "evalhub.env_card": {
            "aggregate_results": {},
            "autograder_bias": {},
            "capture_completeness": 0.15,
            "confidence_intervals": {},
            "cpu_model": "x86_64",
            "custom": {},
            "k8s_pod_labels": {},
            "k8s_resource_limits": {},
            "key_packages": {
              "lm_eval": "0.4.8",
              "torch": "2.6.0",
              "transformers": "4.48.0"
            },
            "os_info": "Linux-5.14.0-570.78.1.el9_6.x86_64-x86_64-with-glibc2.34",
            "per_task_results": {},
            "python_version": "3.11.13",
            "scorer_ids": []
          }
        }
      },
      {
        "id": "truthfulqa_mc1",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 0,
        "metrics": {
          "acc": 0.4,
          "acc_stderr": 0.16329931618554522
        },
        "additional_info": {
          "batch_size": 1,
          "dataset": [
            {
              "hf_repo": "truthful_qa",
              "hf_subset": "multiple_choice",
              "sha": "741b8276f2d1982aa3d5b832d3ee81ed3b896490"
            }
          ],
          "evaluation_date": "2026-07-30T08:35:35.721440+00:00",
          "hf_offline": false,
          "limit": 10,
          "lmeval_version": "0.4.8",
          "num_concurrent": 1,
          "num_fewshot": 0,
          "num_samples_effective": 10,
          "num_samples_original": 817,
          "output_type": "multiple_choice",
          "primary_metric": "acc",
          "random_seed": 42,
          "tags": [
            "truthfulqa"
          ],
          "task_version": 2,
          "timeout_seconds": 300,
          "tokenizer": "meta-llama/Llama-3.2-1B-Instruct",
          "zero_shot": 0.4
        },
        "artifacts": {
          "evalhub.env_card": {
            "aggregate_results": {},
            "autograder_bias": {},
            "capture_completeness": 0.15,
            "confidence_intervals": {},
            "cpu_model": "x86_64",
            "custom": {},
            "k8s_pod_labels": {},
            "k8s_resource_limits": {},
            "key_packages": {
              "lm_eval": "0.4.8",
              "torch": "2.6.0",
              "transformers": "4.48.0"
            },
            "os_info": "Linux-5.14.0-570.78.1.el9_6.x86_64-x86_64-with-glibc2.34",
            "per_task_results": {},
            "python_version": "3.11.13",
            "scorer_ids": []
          }
        }
      },
      {
        "id": "crows_pairs_english",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 3,
        "metrics": {
          "likelihood_diff": 2.521317640261259,
          "likelihood_diff_stderr": 0.4945229161416541,
          "pct_stereotype": 0.6,
          "pct_stereotype_stderr": 0.1632993161855452
        },
        "additional_info": {
          "batch_size": 1,
          "dataset": [
            {
              "hf_repo": "jannalu/crows_pairs_multilingual",
              "hf_subset": "english",
              "sha": "3550adcf6ac84fc021c0cd99114acd35e1f8b88d"
            }
          ],
          "dataset_split": "test",
          "evaluation_date": "2026-07-30T08:35:39.091815+00:00",
          "hf_offline": false,
          "limit": 10,
          "lmeval_version": "0.4.8",
          "num_concurrent": 1,
          "num_fewshot": 0,
          "num_samples_effective": 10,
          "num_samples_original": 1677,
          "output_type": "multiple_choice",
          "primary_metric": "likelihood_diff",
          "random_seed": 42,
          "tags": [
            "crows_pairs"
          ],
          "task_version": 1,
          "timeout_seconds": 300,
          "tokenizer": "meta-llama/Llama-3.2-1B-Instruct",
          "zero_shot": 2.521317640261259
        },
        "artifacts": {
          "evalhub.env_card": {
            "aggregate_results": {},
            "autograder_bias": {},
            "capture_completeness": 0.15,
            "confidence_intervals": {},
            "cpu_model": "x86_64",
            "custom": {},
            "k8s_pod_labels": {},
            "k8s_resource_limits": {},
            "key_packages": {
              "lm_eval": "0.4.8",
              "torch": "2.6.0",
              "transformers": "4.48.0"
            },
            "os_info": "Linux-5.14.0-570.78.1.el9_6.x86_64-x86_64-with-glibc2.34",
            "per_task_results": {},
            "python_version": "3.11.13",
            "scorer_ids": []
          }
        }
      },
      {
        "id": "winogender",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 2,
        "additional_info": {
          "batch_size": 1,
          "evaluation_date": "2026-07-30T08:35:36.989352+00:00",
          "hf_offline": false,
          "limit": 10,
          "lmeval_version": "0.4.8",
          "num_concurrent": 1,
          "num_fewshot": 0,
          "random_seed": 42,
          "timeout_seconds": 300,
          "tokenizer": "meta-llama/Llama-3.2-1B-Instruct"
        },
        "artifacts": {
          "evalhub.env_card": {
            "aggregate_results": {},
            "autograder_bias": {},
            "capture_completeness": 0.15,
            "confidence_intervals": {},
            "cpu_model": "x86_64",
            "custom": {},
            "k8s_pod_labels": {},
            "k8s_resource_limits": {},
            "key_packages": {
              "lm_eval": "0.4.8",
              "torch": "2.6.0",
              "transformers": "4.48.0"
            },
            "os_info": "Linux-5.14.0-570.78.1.el9_6.x86_64-x86_64-with-glibc2.34",
            "per_task_results": {},
            "python_version": "3.11.13",
            "scorer_ids": []
          }
        }
      },
      {
        "id": "ethics_cm",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 5,
        "metrics": {
          "acc": 0.6,
          "acc_stderr": 0.16329931618554522
        },
        "additional_info": {
          "batch_size": 1,
          "dataset": [
            {
              "hf_repo": "EleutherAI/hendrycks_ethics",
              "hf_subset": "commonsense"
            }
          ],
          "dataset_split": "test",
          "evaluation_date": "2026-07-30T08:35:41.209901+00:00",
          "hf_offline": false,
          "limit": 10,
          "lmeval_version": "0.4.8",
          "num_concurrent": 1,
          "num_fewshot": 0,
          "num_samples_effective": 10,
          "num_samples_original": 3885,
          "output_type": "multiple_choice",
          "primary_metric": "acc",
          "random_seed": 42,
          "tags": [
            "hendrycks_ethics"
          ],
          "task_version": 1,
          "timeout_seconds": 300,
          "tokenizer": "meta-llama/Llama-3.2-1B-Instruct",
          "zero_shot": 0.6
        },
        "artifacts": {
          "evalhub.env_card": {
            "aggregate_results": {},
            "autograder_bias": {},
            "capture_completeness": 0.15,
            "confidence_intervals": {},
            "cpu_model": "x86_64",
            "custom": {},
            "k8s_pod_labels": {},
            "k8s_resource_limits": {},
            "key_packages": {
              "lm_eval": "0.4.8",
              "torch": "2.6.0",
              "transformers": "4.48.0"
            },
            "os_info": "Linux-5.14.0-570.78.1.el9_6.x86_64-x86_64-with-glibc2.34",
            "per_task_results": {},
            "python_version": "3.11.13",
            "scorer_ids": []
          }
        }
      },
      {
        "id": "bbq",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 4,
        "metrics": {
          "acc": 0.3,
          "acc_stderr": 0.15275252316519466,
          "accuracy_amb": 0,
          "accuracy_disamb": 0.6,
          "amb_bias_score": 0.19999999999999996,
          "amb_bias_score_Age": 0.19999999999999996,
          "disamb_bias_score": -0.19999999999999996,
          "disamb_bias_score_Age": -0.19999999999999996
        },
        "additional_info": {
          "batch_size": 1,
          "dataset": [
            {
              "hf_repo": "oskarvanderwal/bbq",
              "hf_subset": "All",
              "sha": "ab00114b0fbf59c7c539ff9158f6ce717d13ab63"
            }
          ],
          "dataset_split": "test",
          "evaluation_date": "2026-07-30T08:35:40.322028+00:00",
          "hf_offline": false,
          "limit": 10,
          "lmeval_version": "0.4.8",
          "num_concurrent": 1,
          "num_fewshot": 0,
          "num_samples_effective": 10,
          "num_samples_original": 58492,
          "output_type": "multiple_choice",
          "primary_metric": "acc",
          "random_seed": 42,
          "tags": [
            "social_bias"
          ],
          "task_version": 1,
          "timeout_seconds": 300,
          "tokenizer": "meta-llama/Llama-3.2-1B-Instruct",
          "zero_shot": 0.3
        },
        "artifacts": {
          "evalhub.env_card": {
            "aggregate_results": {},
            "autograder_bias": {},
            "capture_completeness": 0.15,
            "confidence_intervals": {},
            "cpu_model": "x86_64",
            "custom": {},
            "k8s_pod_labels": {},
            "k8s_resource_limits": {},
            "key_packages": {
              "lm_eval": "0.4.8",
              "torch": "2.6.0",
              "transformers": "4.48.0"
            },
            "os_info": "Linux-5.14.0-570.78.1.el9_6.x86_64-x86_64-with-glibc2.34",
            "per_task_results": {},
            "python_version": "3.11.13",
            "scorer_ids": []
          }
        }
      }
    ]
  },
  "name": "model test using collection",
  "model": {
    "url": "https://vllm-llama-prabhu.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1",
    "name": "meta-llama/Llama-3.2-1B-Instruct",
    "auth": {
      "secret_ref": "vllm-api-key"
    }
  },
  "collection": {
    "id": "safety-and-fairness-v1",
    "benchmarks": [
      {
        "id": "bbq",
        "provider_id": "lm_evaluation_harness",
        "parameters": {
          "num_examples": 10
        }
      },
      {
        "id": "crows_pairs_english",
        "provider_id": "lm_evaluation_harness",
        "parameters": {
          "num_examples": 10
        }
      },
      {
        "id": "ethics_cm",
        "provider_id": "lm_evaluation_harness",
        "parameters": {
          "num_examples": 10
        }
      },
      {
        "id": "toxigen",
        "provider_id": "lm_evaluation_harness",
        "parameters": {
          "num_examples": 10
        }
      },
      {
        "id": "winogender",
        "provider_id": "lm_evaluation_harness",
        "parameters": {
          "num_examples": 10
        }
      },
      {
        "id": "truthfulqa_mc1",
        "provider_id": "lm_evaluation_harness",
        "parameters": {
          "num_examples": 10
        }
      }
    ]
  }
}

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved evaluation metric handling by excluding invalid, non-numeric, missing, and non-finite values from aggregation and scoring.
  * Prevented values such as `N/A`, `NaN`, and infinity from affecting benchmark results.

* **Tests**
  * Added coverage to verify valid metric conversion and proper handling of invalid values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->