### PR TITLE
cherry-pick: skip non-finite metric values before reporting results

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,6 +24,7 @@ files and do not call the Hub. You do not need ``parameters.offline``.
 
 import json
 import logging
+import math
 import os
 import re
 import requests
@@ -266,6 +267,23 @@ def _jsonable(value: Any) -> Any:
     if isinstance(value, (list, tuple)):
         return [_jsonable(v) for v in value]
     return str(value)
+
+
+def _to_finite_float(metric_value: Any) -> float | None:
+    """Return a finite float, or None for N/A / non-numeric / NaN / Inf.
+
+    BBQ category bias aggregators return NaN when a category has no examples
+    (common with num_examples/limit); those must not become EvaluationResults.
+    """
+    if metric_value == "N/A" or metric_value is None:
+        return None
+    try:
+        value = float(metric_value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(value):
+        return None
+    return value
 
 
 def _sanitize_error_message(msg: str) -> str:
@@ -776,8 +794,11 @@ class LMEvalAdapter(FrameworkAdapter):
                                 continue
                             if metric_value == "N/A" or metric_value is None:
                                 continue
+                            value = _to_finite_float(metric_value)
+                            if value is None:
+                                continue
                             clean = metric_name.replace(",none", "")
-                            subtask_metrics[clean] = subtask_metrics.get(clean, 0) + float(metric_value)
+                            subtask_metrics[clean] = subtask_metrics.get(clean, 0) + value
                             subtask_count[clean] = subtask_count.get(clean, 0) + 1
                     task_results = {
                         f"{k},none": subtask_metrics[k] / subtask_count[k]
@@ -792,23 +813,22 @@ class LMEvalAdapter(FrameworkAdapter):
                 if metric_name.endswith(",none"):
                     # Primary metric (usually accuracy or similar)
                     clean_metric = metric_name.replace(",none", "")
-                    # lm-eval returns 'N/A' for metrics it cannot compute
-                    # (e.g. when the model produces unparseable outputs).
-                    if metric_value == "N/A" or metric_value is None:
+                    value = _to_finite_float(metric_value)
+                    if value is None:
                         logger.warning(
-                            "Metric %s has value N/A, skipping",
+                            "Metric %s has value N/A or non-finite, skipping",
                             clean_metric,
                         )
                         continue
                     evaluation_results.append(
                         EvaluationResult(
                             metric_name=clean_metric,
-                            metric_value=float(metric_value),
+                            metric_value=value,
                         )
                     )
                     # Use first primary metric as overall score
                     if overall_score is None:
-                        overall_score = float(metric_value)
+                        overall_score = value
 
             # Capture run metadata for generate_additional_info() — needs overall_score
             self._run_info = _build_additional_info(

--- a/main.py
+++ b/main.py
@@ -279,7 +279,7 @@ def _to_finite_float(metric_value: Any) -> float | None:
         return None
     try:
         value = float(metric_value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return None
     if not math.isfinite(value):
         return None

--- a/tests/test_metric_candidates.py
+++ b/tests/test_metric_candidates.py
@@ -1,5 +1,7 @@
 """Unit tests for skipping non-finite lm-eval metric values (BBQ NaN/Inf)."""
 
+from decimal import Decimal
+
 import pytest
 
 from main import _to_finite_float
@@ -17,6 +19,7 @@ from main import _to_finite_float
         (float("inf"), None),
         (float("-inf"), None),
         ("not-a-number", None),
+        (Decimal("1e10000"), None),  # float() raises OverflowError
     ],
 )
 def test_to_finite_float(raw: object, expected: float | None) -> None:

--- a/tests/test_metric_candidates.py
+++ b/tests/test_metric_candidates.py
@@ -1,0 +1,27 @@
+"""Unit tests for skipping non-finite lm-eval metric values (BBQ NaN/Inf)."""
+
+import pytest
+
+from main import _to_finite_float
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (0.9, 0.9),
+        (1, 1.0),
+        ("0.5", 0.5),
+        ("N/A", None),
+        (None, None),
+        (float("nan"), None),
+        (float("inf"), None),
+        (float("-inf"), None),
+        ("not-a-number", None),
+    ],
+)
+def test_to_finite_float(raw: object, expected: float | None) -> None:
+    got = _to_finite_float(raw)
+    if expected is None:
+        assert got is None
+    else:
+        assert got == pytest.approx(expected)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Cherrypick from https://github.com/opendatahub-io/lm-evaluation-harness/pull/180
## Problem:

BBQ was failing with Failed to save to MLflow: Out of range float values are not JSON compliant/Failed to send results to evalhub: Out of range float values are not JSON compliant when users set a small num_examples.
https://redhat.atlassian.net/browse/RHOAIENG-79800

## Description
<!--- Describe your changes in detail -->

- Skip NaN/Inf (and other non-finite) metric values when building EvaluationResults from lm-eval output.
- BBQ category bias aggregators return NaN when a category has no examples (common with num_examples/limit); those values break JSON and MLflow serialization.
- Add unit tests for _to_finite_float.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested the bbq benchmark with the fix, evaluation went fine and the metrics are stored properly in evaluation meta and MLFlow.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
